### PR TITLE
add import-export editor file (#60)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2239,9 +2239,9 @@
       }
     },
     "@types/jest": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
-      "integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
+      "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
       "requires": {
         "jest-diff": "^27.0.0",
         "pretty-format": "^27.0.0"
@@ -2278,14 +2278,14 @@
           "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ=="
         },
         "jest-diff": {
-          "version": "27.1.1",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.1.tgz",
-          "integrity": "sha512-m/6n5158rqEriTazqHtBpOa2B/gGgXJijX6nsEgZfbJ/3pxQcdpVXBe+FP39b1dxWHyLVVmuVXddmAwtqFO4Lg==",
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.0.tgz",
+          "integrity": "sha512-QSO9WC6btFYWtRJ3Hac0sRrkspf7B01mGrrQEiCW6TobtViJ9RWL0EmOs/WnBsZDsI/Y2IoSHZA2x6offu0sYw==",
           "requires": {
             "chalk": "^4.0.0",
             "diff-sequences": "^27.0.6",
             "jest-get-type": "^27.0.6",
-            "pretty-format": "^27.1.1"
+            "pretty-format": "^27.2.0"
           }
         },
         "jest-get-type": {
@@ -2294,9 +2294,9 @@
           "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg=="
         },
         "pretty-format": {
-          "version": "27.1.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.1.tgz",
-          "integrity": "sha512-zdBi/xlstKJL42UH7goQti5Hip/B415w1Mfj+WWWYMBylAYtKESnXGUtVVcMVid9ReVjypCotUV6CEevYPHv2g==",
+          "version": "27.2.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.0.tgz",
+          "integrity": "sha512-KyJdmgBkMscLqo8A7K77omgLx5PWPiXJswtTtFV7XgVZv2+qPk6UivpXXO+5k6ZEbWIbLoKdx1pZ6ldINzbwTA==",
           "requires": {
             "@jest/types": "^27.1.1",
             "ansi-regex": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2317,9 +2317,9 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "@types/node": {
-      "version": "16.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
-      "integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA=="
+      "version": "16.9.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.6.tgz",
+      "integrity": "sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2455,9 +2455,9 @@
       }
     },
     "@types/three": {
-      "version": "0.131.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.131.1.tgz",
-      "integrity": "sha512-unnjsolcm7R90e4XK9qMq4JYEzly0XQNa0pG8RAOMZeVzj3FLIFPymAYUx4Osz0gY9jFZz8omIQplqiieEE7gw==",
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.132.0.tgz",
+      "integrity": "sha512-NCZ7KbGMa0l8z8Pk4cNCw3tSST+keOXeD9IXdiOJWQnVaFpbUpE/wIdbalkK1c0fs/Z+OZzjLZEWf2zRoVGOCg==",
       "dev": true
     },
     "@types/throttle-debounce": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2347,9 +2347,9 @@
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
     },
     "@types/react": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.21.tgz",
-      "integrity": "sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==",
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.24.tgz",
+      "integrity": "sha512-eIpyco99gTH+FTI3J7Oi/OH8MZoFMJuztNRimDOJwH4iGIsKV2qkGnk4M9VzlaVWeEEWLWSQRy0FEA0Kz218cg==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     ]
   },
   "devDependencies": {
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.24",
     "@types/react-async-script": "^1.2.1",
     "@types/three": "^0.132.0",
     "react-app-rewired": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^12.1.0",
     "@testing-library/user-event": "^13.2.1",
-    "@types/jest": "^27.0.1",
+    "@types/jest": "^27.0.2",
     "@types/node": "^16.9.6",
     "@types/react-dom": "^17.0.0",
     "@types/signals": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@types/react": "^17.0.21",
     "@types/react-async-script": "^1.2.1",
-    "@types/three": "^0.131.1",
+    "@types/three": "^0.132.0",
     "react-app-rewired": "^2.1.8",
     "worker-loader": "^3.0.8",
     "gh-pages": "^3.2.3"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@testing-library/react": "^12.1.0",
     "@testing-library/user-event": "^13.2.1",
     "@types/jest": "^27.0.1",
-    "@types/node": "^16.9.4",
+    "@types/node": "^16.9.6",
     "@types/react-dom": "^17.0.0",
     "@types/signals": "^1.0.1",
     "@types/throttle-debounce": "^2.1.0",

--- a/src/ThreeEditor/js/Editor.js
+++ b/src/ThreeEditor/js/Editor.js
@@ -694,7 +694,7 @@ Editor.prototype = {
 
 		this.zonesManager.copy(zonesManager);
 		this.signals.sceneGraphChanged.dispatch();
-				
+
 		this.signals.loadedFromJSON.dispatch(this);
 	},
 
@@ -721,7 +721,11 @@ Editor.prototype = {
 
 		return {
 
-			metadata: {},
+			metadata: {
+				'version': 0.1,
+				'type': 'Editor',
+				'generator': 'Editor.toJSON'
+			},
 			project: {
 				shadows: this.config.getKey('project/renderer/shadows'),
 				shadowType: this.config.getKey('project/renderer/shadowType'),

--- a/src/ThreeEditor/js/Loader.js
+++ b/src/ThreeEditor/js/Loader.js
@@ -199,9 +199,14 @@ function Loader(editor) {
 
 				break;
 
-			case 'app':
+			case 'editor':
 
-				editor.fromJSON(data);
+				if (window.confirm('Current editor data will be lost. Are you sure?')) {
+
+					editor.clear();
+					editor.fromJSON(data);
+
+				}
 
 				break;
 

--- a/src/ThreeEditor/js/Menubar.File.js
+++ b/src/ThreeEditor/js/Menubar.File.js
@@ -36,7 +36,7 @@ function MenubarFile(editor) {
 
 	options.add(new UIHorizontalRule());
 
-	// Open Editor
+	// Open Editor from file
 
 	var form = document.createElement('form');
 	form.style.display = 'none';
@@ -68,11 +68,11 @@ function MenubarFile(editor) {
 	options.add(new UIHorizontalRule());
 
 
-	// Export Editor
+	// Save Editor to file
 
 	option = new UIRow();
 	option.setClass('option');
-	option.setTextContent('Export');
+	option.setTextContent('Save');
 	option.onClick(function () {
 
 		var output = editor.toJSON();
@@ -88,7 +88,7 @@ function MenubarFile(editor) {
 
 		}
 
-		const fileName = window.prompt('Input file name ', 'editor');
+		const fileName = window.prompt('Name of the file', 'editor');
 
 		if (fileName)
 			saveString(output, `${fileName}.json`);
@@ -115,11 +115,6 @@ function MenubarFile(editor) {
 
 	}
 
-	function saveArrayBuffer(buffer, filename) {
-
-		save(new Blob([buffer], { type: 'application/octet-stream' }), filename);
-
-	}
 
 	function saveString(text, filename) {
 

--- a/src/ThreeEditor/js/Menubar.File.js
+++ b/src/ThreeEditor/js/Menubar.File.js
@@ -2,7 +2,6 @@ import { UIHorizontalRule, UIPanel, UIRow } from './libs/ui.js';
 
 function MenubarFile(editor) {
 
-	var config = editor.config;
 	var strings = editor.strings;
 
 	var container = new UIPanel();
@@ -37,7 +36,7 @@ function MenubarFile(editor) {
 
 	options.add(new UIHorizontalRule());
 
-	// Import
+	// Open Editor
 
 	var form = document.createElement('form');
 	form.style.display = 'none';
@@ -56,7 +55,7 @@ function MenubarFile(editor) {
 
 	option = new UIRow();
 	option.setClass('option');
-	option.setTextContent(strings.getKey('menubar/file/import'));
+	option.setTextContent('Open');
 	option.onClick(function () {
 
 		fileInput.click();
@@ -68,37 +67,20 @@ function MenubarFile(editor) {
 
 	options.add(new UIHorizontalRule());
 
-	// Export Geometry
+
+	// Export Editor
 
 	option = new UIRow();
 	option.setClass('option');
-	option.setTextContent(strings.getKey('menubar/file/export/geometry'));
+	option.setTextContent('Export');
 	option.onClick(function () {
 
-		var object = editor.selected;
-
-		if (object === null) {
-
-			alert('No object selected.');
-			return;
-
-		}
-
-		var geometry = object.geometry;
-
-		if (geometry === undefined) {
-
-			alert('The selected object doesn\'t have geometry.');
-			return;
-
-		}
-
-		var output = geometry.toJSON();
+		var output = editor.toJSON();
 
 		try {
 
 			output = JSON.stringify(output, null, '\t');
-			output = output.replace(/[\n\t]+([\d\.e\-\[\]]+)/g, '$1'); // eslint-disable-line
+			output = output.replace(/[\n\t]+([\d.e\-[\]]+)/g, '$1');
 
 		} catch (e) {
 
@@ -106,66 +88,10 @@ function MenubarFile(editor) {
 
 		}
 
-		saveString(output, 'geometry.json');
+		const fileName = window.prompt('Input file name ', 'editor');
 
-	});
-	options.add(option);
-
-	// Export Object
-
-	option = new UIRow();
-	option.setClass('option');
-	option.setTextContent(strings.getKey('menubar/file/export/object'));
-	option.onClick(function () {
-
-		var object = editor.selected;
-
-		if (object === null) {
-
-			alert('No object selected');
-			return;
-
-		}
-
-		var output = object.toJSON();
-
-		try {
-
-			output = JSON.stringify(output, null, '\t');
-			output = output.replace(/[\n\t]+([\d\.e\-\[\]]+)/g, '$1'); // eslint-disable-line
-
-		} catch (e) {
-
-			output = JSON.stringify(output);
-
-		}
-
-		saveString(output, 'model.json');
-
-	});
-	options.add(option);
-
-	// Export Scene
-
-	option = new UIRow();
-	option.setClass('option');
-	option.setTextContent(strings.getKey('menubar/file/export/scene'));
-	option.onClick(function () {
-
-		var output = editor.scene.toJSON();
-
-		try {
-
-			output = JSON.stringify(output, null, '\t');
-			output = output.replace(/[\n\t]+([\d\.e\-\[\]]+)/g, '$1'); // eslint-disable-line
-
-		} catch (e) {
-
-			output = JSON.stringify(output);
-
-		}
-
-		saveString(output, 'scene.json');
+		if (fileName)
+			saveString(output, `${fileName}.json`);
 
 	});
 	options.add(option);
@@ -201,19 +127,6 @@ function MenubarFile(editor) {
 
 	}
 
-	function getAnimations(scene) {
-
-		var animations = [];
-
-		scene.traverse(function (object) {
-
-			animations.push(...object.animations);
-
-		});
-
-		return animations;
-
-	}
 
 	return container;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1909,10 +1909,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.21":
-  version "17.0.21"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.21.tgz#069c43177cd419afaab5ce26bb4e9056549f7ea6"
-  integrity sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==
+"@types/react@*", "@types/react@^17.0.24":
+  version "17.0.24"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.24.tgz#7e1b3f78d0fc53782543f9bce6d949959a5880bd"
+  integrity sha512-eIpyco99gTH+FTI3J7Oi/OH8MZoFMJuztNRimDOJwH4iGIsKV2qkGnk4M9VzlaVWeEEWLWSQRy0FEA0Kz218cg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1867,10 +1867,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*", "@types/node@^16.9.4":
-  version "16.9.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.4.tgz#a12f0ee7847cf17a97f6fdf1093cb7a9af23cca4"
-  integrity sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA==
+"@types/node@*", "@types/node@^16.9.6":
+  version "16.9.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.6.tgz#040a64d7faf9e5d9e940357125f0963012e66f04"
+  integrity sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,17 +1394,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jest/types@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.6.tgz#9a992bc517e0c49f035938b8549719c2de40706b"
-  integrity sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^16.0.0"
-    chalk "^4.0.0"
-
 "@jest/types@^27.1.1":
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.1.1.tgz#77a3fc014f906c65752d12123a0134359707c0ad"
@@ -1844,10 +1833,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@*", "@types/jest@^27.0.1":
-  version "27.0.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.1.tgz#fafcc997da0135865311bb1215ba16dba6bdf4ca"
-  integrity sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==
+"@types/jest@*", "@types/jest@^27.0.2":
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.2.tgz#ac383c4d4aaddd29bbf2b916d8d105c304a5fcd7"
+  integrity sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==
   dependencies:
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
@@ -9064,17 +9053,7 @@ pretty-format@^26.6.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^27.0.0, pretty-format@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.0.6.tgz#ab770c47b2c6f893a21aefc57b75da63ef49a11f"
-  integrity sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==
-  dependencies:
-    "@jest/types" "^27.0.6"
-    ansi-regex "^5.0.0"
-    ansi-styles "^5.0.0"
-    react-is "^17.0.1"
-
-pretty-format@^27.0.2:
+pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.0.6:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.1.1.tgz#cbaf9ec6cd7cfc3141478b6f6293c0ccdbe968e0"
   integrity sha512-zdBi/xlstKJL42UH7goQti5Hip/B415w1Mfj+WWWYMBylAYtKESnXGUtVVcMVid9ReVjypCotUV6CEevYPHv2g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1968,10 +1968,10 @@
   dependencies:
     "@types/jest" "*"
 
-"@types/three@^0.131.1":
-  version "0.131.1"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.131.1.tgz#2ee511383c8620f6ce301582214122319e6aca34"
-  integrity sha512-unnjsolcm7R90e4XK9qMq4JYEzly0XQNa0pG8RAOMZeVzj3FLIFPymAYUx4Osz0gY9jFZz8omIQplqiieEE7gw==
+"@types/three@^0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.132.0.tgz#d2d4c8336faf993855c0a5933d7107d4e70de9b6"
+  integrity sha512-NCZ7KbGMa0l8z8Pk4cNCw3tSST+keOXeD9IXdiOJWQnVaFpbUpE/wIdbalkK1c0fs/Z+OZzjLZEWf2zRoVGOCg==
 
 "@types/throttle-debounce@^2.1.0":
   version "2.1.0"


### PR DESCRIPTION
Added possibility to export state of the editor to a file and import state from a file.

![obraz](https://user-images.githubusercontent.com/26521377/134202754-9074700c-5363-4a61-b449-25b0ef16cff1.png)

Closes #60.
