### PR TITLE
hide old sidebar

### DIFF
--- a/src/ThreeEditor/js/Editor.js
+++ b/src/ThreeEditor/js/Editor.js
@@ -127,6 +127,8 @@ export function Editor(container) {
 
 	this.results = null;
 
+	this.oldSidebarVisible = true;
+
 	this.container = container;
 	container.setAttribute('tabindex', '-1');
 	this.container.focus();

--- a/src/ThreeEditor/main.js
+++ b/src/ThreeEditor/main.js
@@ -28,6 +28,17 @@ export function initEditor(container) {
 	const sidebar = new Sidebar(editor);
 	container.appendChild(sidebar.dom);
 
+	Object.defineProperty(editor, "oldSidebarVisible", {
+		get: function () {
+			return sidebar.getDisplay() !== "none";
+		},
+		set: function (val) {
+			sidebar.setDisplay(val ? "" : "none");
+		}
+	});
+
+	editor.oldSidebarVisible = false;
+
 	const menubar = new Menubar(editor);
 	// menubar has required dependencies for other UI components and will be removed last.
 


### PR DESCRIPTION
In order to enable the old sidebar you write in the browser console:
```
editor.oldSidebarVisible = true;
```