### PR TITLE
set retry amount to 0

### DIFF
--- a/src/services/AuthService.tsx
+++ b/src/services/AuthService.tsx
@@ -65,6 +65,7 @@ const Auth = ({ children }: AuthProps) => {
 		ky.create({
 			credentials: 'include',
 			prefixUrl: BACKEND_URL,
+			retry: 0,
 			//overwrite default json parser to convert snake_case to camelCase
 			parseJson: (text: string) => snakeToCamelCase(JSON.parse(text), true),
 			hooks: {


### PR DESCRIPTION
This should prevent the frontend from spamming slowed down the backend with waves of requests if requests set up on interval start to timeout.