### PR TITLE
building process adapted to the python 3.11

### DIFF
--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -12,15 +12,17 @@ env:
 jobs:
   build_and_test:
 
-    runs-on: ubuntu-latest
-
     # Only run if it is a PR and the comment contains /test
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/test')
 
     strategy:
       matrix:
         node-version: [18.x]
+        operating-system: [ubuntu-latest, windows-latest]
+        python-version: ['3.10', '3.11']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    runs-on: ${{ matrix.operating-system }}
 
     steps:
       - name: Get branch of PR
@@ -41,7 +43,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -52,10 +52,9 @@ jobs:
           command: npm test	
 
   deploy-to-github-registry:
-    # needs: build_and_test
-    # this is a lengthy process, lets run it in parallel to build_and_test
+    needs: [build_and_test]
     runs-on: ubuntu-latest
-    
+    if: github.ref == 'refs/heads/master'    
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}-web

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM node:18 AS build
 # Install python3-pip via apt and clean cache.
 # pip is needed to generate a wheel package for the converter part of the UI,
 # which is later called using pyodide (Python in the browser).
-RUN apt-get update && apt-get install -y --no-install-recommends python3-pip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends python3-pip python3-venv && rm -rf /var/lib/apt/lists/*
 
 # Directory where the app is installed and run.
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## For users
 
-The development version is unstable, without many features and with lot of bugs.
+The development version is unstable, without many features and with a lot of bugs.
 It is released automatically after every commit to the main branch of this repository and is available for testing here:
 <https://yaptide.github.io/web_dev/>
 
 The stable version is not released yet, have patience.
 
-### Loading a project file with results from URL
+### Loading a project file with results from a URL
 
 You can load a project file with results from a URL by adding `?<project_file_url>` to the end of the editor URL.
 
@@ -28,7 +28,7 @@ Start by downloading submodules:
 git submodule update --init --recursive
 ```
 
-Before starting the local version of the web interface, you need to install the necessary dependencies by typing command:
+Before starting the local version of the web interface, you need to install the necessary dependencies by typing the command:
 
 ```bash
 npm install
@@ -69,7 +69,7 @@ docker run --rm -d -p 80:80/tcp --name ui ui
 The docker image is generated automatically after every commit to the main branch of this repository.
 The package is here https://github.com/yaptide/ui/pkgs/container/ui-web
 
-Command below will run the docker container named `ui` and serve the UI on port 80:
+The command below will run the docker container named `ui` and serve the UI on port 80:
 
 ```bash
 docker run --rm -d -p 80:80/tcp --name ui ghcr.io/yaptide/ui-web:master
@@ -81,9 +81,9 @@ This project adapts source code from the following libraries:
 
 - CSG javascript library <https://github.com/manthrax/THREE-CSGMesh>
   - parts of its code copied into `src/ThreeEditor/js/libs/csg/`
-  - adapted by adding types in separate file
-- ThreeJS editor <https://threejs.org/editor/>
-  - most of its code copied from [github mrdoob repo](https://github.com/mrdoob/three.js/tree/r132/editor) into `src/ThreeEditor`, starting from v.132
-  - most of copied code adapted to yaptide needs
+  - adapted by adding types in a separate file
+- ThreeJS Editor <https://threejs.org/editor/>
+  - most of its code is copied from [mrdoob's GitHub repo](https://github.com/mrdoob/three.js/tree/r132/editor) into `src/ThreeEditor`, starting from v.132
+  - the copied code is heavily adapted to "yaptide needs"
 
 This work was partially funded by EuroHPC PL Project, Smart Growth Operational Programme 4.2

--- a/README.md
+++ b/README.md
@@ -44,11 +44,25 @@ Then open [http://localhost:3000/web_dev](http://localhost:3000/web_dev) to view
 
 The page will reload if you make edits.
 
+### Building the app using the Dockerfile
+
+To build the docker image, type:
+
+```bash
+docker build -t ui .
+```
+
+Then you can run the docker container named `ui` and serve the UI on port 80:
+
+```bash
+docker run --rm -d -p 80:80/tcp --name ui ui
+```
+
 ## Requirements
 
 - Node.js 18.x or higher
 - Python 3.9+
-- pip
+- pip and venv
 
 ## Private docker image generated in the GHCR
 
@@ -58,7 +72,7 @@ The package is here https://github.com/yaptide/ui/pkgs/container/ui-web
 Command below will run the docker container named `ui` and serve the UI on port 80:
 
 ```bash
-docker run --rm -d -p 80:80/tcp --name ui ghcr.io/yaptide/ui-web:latest
+docker run --rm -d -p 80:80/tcp --name ui ghcr.io/yaptide/ui-web:master
 ```
 
 ## Credits

--- a/buildPython.js
+++ b/buildPython.js
@@ -62,14 +62,20 @@ const saveFileName = (destFolder, fileName) => {
 			console.timeEnd(label);
 		};
 
+		measureTime('Create venv environment', () => {
+			execSync(`${PYTHON} -m venv venv`, {
+				cwd: srcFolder
+			});
+		});
+
 		measureTime('Installing build module for python', () => {
-			execSync(`${PYTHON} -m pip install build wheel`, {
+			execSync(`. venv/bin/activate && ${PYTHON} -m pip install build wheel`, {
 				cwd: srcFolder
 			});
 		});
 
 		measureTime('Building yaptide_converter', () => {
-			execSync(`${PYTHON} -m build --wheel --no-isolation`, {
+			execSync(`. venv/bin/activate && ${PYTHON} -m build --wheel --no-isolation`, {
 				cwd: srcFolder
 			});
 		});

--- a/buildPython.js
+++ b/buildPython.js
@@ -3,6 +3,7 @@ const glob = require('glob');
 const path = require('path');
 const { execSync } = require('child_process');
 const { exit } = require('process');
+const os = require('os');
 
 const SKIP = process.argv[2] === 'skip';
 
@@ -68,14 +69,17 @@ const saveFileName = (destFolder, fileName) => {
 			});
 		});
 
+		const activateCmd =
+			os.platform() === 'win32' ? 'venv\\Scripts\\activate.ps1' : '. venv/bin/activate';
+
 		measureTime('Installing build module for python', () => {
-			execSync(`. venv/bin/activate && ${PYTHON} -m pip install build wheel`, {
+			execSync(`${activateCmd} && ${PYTHON} -m pip install build wheel`, {
 				cwd: srcFolder
 			});
 		});
 
 		measureTime('Building yaptide_converter', () => {
-			execSync(`. venv/bin/activate && ${PYTHON} -m build --wheel --no-isolation`, {
+			execSync(`${activateCmd} && ${PYTHON} -m build --wheel --no-isolation`, {
 				cwd: srcFolder
 			});
 		});

--- a/src/WrapperApp/components/Simulation/SimulationPanel.tsx
+++ b/src/WrapperApp/components/Simulation/SimulationPanel.tsx
@@ -64,7 +64,7 @@ export default function SimulationPanel({
 
 	const [pageIdx, setPageIdx] = useState(0);
 	const [pageCount, setPageCount] = useState(0);
-	const [orderType, setOrderType] = useState<OrderType>(OrderType.ASCEND);
+	const [orderType, setOrderType] = useState<OrderType>(OrderType.DESCEND);
 	const [orderBy, setOrderBy] = useState<OrderBy>(OrderBy.START_TIME);
 	const [pageSize, setPageSize] = useState(6);
 	type PageState = Omit<


### PR DESCRIPTION
It seems that recently a `node:18` docker image got an upgrade of Python version from 3.10 to 3.11.
In the main dockerfile we've been using pip to install some packages needed to build and install converter pip package.
In 3.10 it was still possible to install packages via pip system-wide.
New python version 3.11 gives an error when user wants to install package via pip system-wide and forces users to use venv.
This PR adjusts the preparation of the converter package to use venv as well.

The change is necessary to have properly working deploy process.