### PR TITLE
Install setuptools

### DIFF
--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         node-version: [18.x]
         operating-system: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     runs-on: ${{ matrix.operating-system }}

--- a/buildPython.js
+++ b/buildPython.js
@@ -89,7 +89,7 @@ const saveFileName = (destFolder, fileName) => {
 		});
 
 		measureTime('Installing build module for python', () => {
-			executeCommand(`${venvCommandPrefix} pip install build wheel ${venvCommandSuffix}`);
+			executeCommand(`${venvCommandPrefix} pip install build wheel setuptools ${venvCommandSuffix}`);
 		});
 
 		measureTime('Building yaptide_converter', () => {


### PR DESCRIPTION
Running `npm run start` failed for me with the following error. I am using Windows and Python 3.12. This change fixed the issue
![obraz](https://github.com/yaptide/ui/assets/92746092/ec37595a-8af9-4229-9368-3c4ec72347a1)
