### PR TITLE
add particle name to json

### DIFF
--- a/src/ThreeEditor/Simulation/Physics/Beam.ts
+++ b/src/ThreeEditor/Simulation/Physics/Beam.ts
@@ -46,6 +46,7 @@ export type BeamJSON = Omit<
 		};
 		particle: {
 			id: number;
+			name: string;
 			z: number;
 			a: number;
 		};
@@ -83,6 +84,7 @@ const _default = {
 	},
 	particle: {
 		id: 2,
+		name: 'Proton',
 		a: 1,
 		z: 1
 	},
@@ -157,6 +159,7 @@ export class Beam extends SimulationElement {
 
 	particleData: {
 		id: number;
+		name: string;
 		z: number;
 		a: number;
 	};

--- a/src/ThreeEditor/components/Sidebar/properties/category/BeamConfiguration.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/BeamConfiguration.tsx
@@ -241,7 +241,14 @@ function BeamConfigurationFields(props: { editor: YaptideEditor; object: Beam })
 					particles={PARTICLE_TYPES}
 					value={watchedObject.particleData.id}
 					onChange={(_, v) =>
-						setValueCommand({ ...watchedObject.particleData, id: v }, 'particleData')
+						setValueCommand(
+							{
+								...watchedObject.particleData,
+								id: v,
+								name: PARTICLE_TYPES.find(p => p.id === v)?.name
+							},
+							'particleData'
+						)
 					}
 				/>
 			</PropertyField>

--- a/src/ThreeEditor/js/sidebar/object/Object.Beam.ts
+++ b/src/ThreeEditor/js/sidebar/object/Object.Beam.ts
@@ -1,3 +1,4 @@
+import { PARTICLE_TYPES } from '../../../../types/Particle';
 import {
 	createParticleTypeSelect,
 	createRowParamNumber,


### PR DESCRIPTION
send particle name along with id to backend. Reason is to add particle name to comment in shieldhit input file (see linked issue)