### PR TITLE
Add aria labels

### DIFF
--- a/src/ThreeEditor/components/Dialog/LoadFileDialog.tsx
+++ b/src/ThreeEditor/components/Dialog/LoadFileDialog.tsx
@@ -42,12 +42,14 @@ export function LoadFileDialog({
 				)
 			}>
 			<Button
+				aria-label='cancel'
 				onClick={onClose}
 				autoFocus>
 				Cancel
 			</Button>
 			<Button
 				disabled={!data}
+				aria-label='clear and proceed'
 				onClick={() => {
 					onClose();
 


### PR DESCRIPTION
This pull request includes a small change to the `LoadFileDialog` component in the `src/ThreeEditor/components/Dialog/LoadFileDialog.tsx` file. The change adds `aria-label` attributes to the 'Cancel' and 'Clear and Proceed' buttons to improve accessibility.

Accessibility improvements:

* [`src/ThreeEditor/components/Dialog/LoadFileDialog.tsx`](diffhunk://#diff-93a5dd4d70deaec3dfb3a111218e58714d614842f5577d3cb7834f7c9c132920R45-R52): Added `aria-label='cancel'` to the 'Cancel' button and `aria-label='clear and proceed'` to the 'Clear and Proceed' button.