### PR TITLE
Ui changes for adjusted estimator db model

### DIFF
--- a/src/WrapperApp/components/Results/EstimatorsSelect/EstimatorsSelect.tsx
+++ b/src/WrapperApp/components/Results/EstimatorsSelect/EstimatorsSelect.tsx
@@ -34,7 +34,7 @@ const EstimatorsSelect = ({
 				const estimatorData = await getJobResult(
 					{
 						jobId: simulationJobId,
-						estimatorName: estimatorsTabData[id] + '_'
+						estimatorName: estimatorsTabData[id]
 					},
 					controller.signal,
 					true

--- a/src/WrapperApp/components/Results/ResultsPanel.tsx
+++ b/src/WrapperApp/components/Results/ResultsPanel.tsx
@@ -28,9 +28,7 @@ function ResultsPanel() {
 	const [estimatorsResults, setEstimatorsResults] = useState<EstimatorResults[]>([]);
 	const [groupQuantities, setGroupQuantities] = useState(false);
 
-	const userTabInputFilesEstimatorNames = simulation?.input.userInputFilesEstimatorNames?.map(
-		output => output.slice(0, -1)
-	);
+	const userTabInputFilesEstimatorNames = simulation?.input.userInputFilesEstimatorNames;
 	const uploadedInputFilesEstimatorNames = estimatorsResults?.map(estimator => estimator.name);
 
 	const editorEstimatorNames = simulation?.input.inputJson?.scoringManager.outputs

--- a/src/services/ShSimulatorService.tsx
+++ b/src/services/ShSimulatorService.tsx
@@ -586,7 +586,7 @@ const ShSimulation = ({ children }: GenericContextProviderProps) => {
 			}
 
 			if (firstEstimatorName) {
-				return firstEstimatorName + '_';
+				return firstEstimatorName;
 			}
 		},
 		[]

--- a/src/services/ShSimulatorService.tsx
+++ b/src/services/ShSimulatorService.tsx
@@ -87,18 +87,6 @@ export interface RestSimulationContext {
 	) => Promise<FullSimulationData | undefined>;
 }
 
-const recreateOrderInEstimators = (
-	estimators: Estimator[],
-	scoringManagerJSON: ScoringManagerJSON
-): Estimator[] => {
-	return orderAccordingToList(
-		estimators,
-		scoringManagerJSON.outputs,
-		'name',
-		(e, o) => (e.scoringOutputJsonRef = o)
-	);
-};
-
 const recreateRefToFilters = (estimators: Estimator[], FiltersJSON: FilterJSON[]): Estimator[] => {
 	estimators.forEach(estimator => {
 		const { pages, scoringOutputJsonRef } = estimator;
@@ -119,11 +107,7 @@ export const recreateRefsInResults = (inputJson: EditorJson, estimators: Estimat
 
 	const { scoringManager }: EditorJson = inputJson;
 
-	const estimatorsOrdered = recreateOrderInEstimators(estimators, scoringManager);
-	const estimatorsWithFixedFilters = recreateRefToFilters(
-		estimatorsOrdered,
-		scoringManager.filters
-	);
+	const estimatorsWithFixedFilters = recreateRefToFilters(estimators, scoringManager.filters);
 
 	return estimatorsWithFixedFilters;
 };


### PR DESCRIPTION
PR needed by https://github.com/yaptide/yaptide/pull/1243

This pull request includes several changes to the `src/WrapperApp/components/Results` and `src/services/ShSimulatorService.tsx` files to improve the handling of estimator names and refactoring of the code. The most important changes include removing the trailing underscore from estimator names, simplifying the `ResultsPanel` component, and refactoring the `ShSimulatorService` to remove unused functions.

Changes to estimator names:

* [`src/WrapperApp/components/Results/EstimatorsSelect/EstimatorsSelect.tsx`](diffhunk://#diff-86366529814e7f6c49e009e561f2d2d2d7056fe18857c39dcf3b822e863f5294L37-R37): Removed the trailing underscore from the `estimatorName` in the `getJobResult` call.
* [`src/services/ShSimulatorService.tsx`](diffhunk://#diff-2179512f339e13f570cb0371ad115ca927d2e7a48929797fd97671033ae6aa05L589-R573): Removed the trailing underscore from the `firstEstimatorName` in the `ShSimulation` function.

Simplification of `ResultsPanel` component:

* [`src/WrapperApp/components/Results/ResultsPanel.tsx`](diffhunk://#diff-82bd4c60a13ac5b7f8d5b0a58abb8a31ff072dc2df7a2643dde6b010c5f822d4L31-R31): Simplified the `userTabInputFilesEstimatorNames` by removing the slicing operation.

Refactoring of `ShSimulatorService`:

* [`src/services/ShSimulatorService.tsx`](diffhunk://#diff-2179512f339e13f570cb0371ad115ca927d2e7a48929797fd97671033ae6aa05L90-L101): Removed the `recreateOrderInEstimators` function and updated the `recreateRefsInResults` function to directly use `recreateRefToFilters`. [[1]](diffhunk://#diff-2179512f339e13f570cb0371ad115ca927d2e7a48929797fd97671033ae6aa05L90-L101) [[2]](diffhunk://#diff-2179512f339e13f570cb0371ad115ca927d2e7a48929797fd97671033ae6aa05L122-R110)