### PR TITLE
Fix for missing filters

### DIFF
--- a/src/services/ShSimulatorService.tsx
+++ b/src/services/ShSimulatorService.tsx
@@ -87,6 +87,17 @@ export interface RestSimulationContext {
 	) => Promise<FullSimulationData | undefined>;
 }
 
+const recreateRefToScoringManagerOutputs = (
+	estimators: Estimator[],
+	scoringManagerJSON: ScoringManagerJSON
+): Estimator[] => {
+	estimators.forEach((estimator, index) => {
+		estimator.scoringOutputJsonRef = scoringManagerJSON.outputs[index];
+	});
+
+	return estimators;
+};
+
 const recreateRefToFilters = (estimators: Estimator[], FiltersJSON: FilterJSON[]): Estimator[] => {
 	estimators.forEach(estimator => {
 		const { pages, scoringOutputJsonRef } = estimator;
@@ -107,7 +118,15 @@ export const recreateRefsInResults = (inputJson: EditorJson, estimators: Estimat
 
 	const { scoringManager }: EditorJson = inputJson;
 
-	const estimatorsWithFixedFilters = recreateRefToFilters(estimators, scoringManager.filters);
+	const estimatorsWithScoringManagerOutputs = recreateRefToScoringManagerOutputs(
+		estimators,
+		scoringManager
+	);
+
+	const estimatorsWithFixedFilters = recreateRefToFilters(
+		estimatorsWithScoringManagerOutputs,
+		scoringManager.filters
+	);
 
 	return estimatorsWithFixedFilters;
 };


### PR DESCRIPTION
This pull request includes changes to the `src/services/ShSimulatorService.tsx` file to introduce a new function for updating estimator references and integrate it into the existing workflow. The most important changes include the addition of the `recreateRefToScoringManagerOutputs` function and its usage within the `recreateRefsInResults` function.

### New function addition:
* [`src/services/ShSimulatorService.tsx`](diffhunk://#diff-2179512f339e13f570cb0371ad115ca927d2e7a48929797fd97671033ae6aa05R90-R100): Added the `recreateRefToScoringManagerOutputs` function to update the `scoringOutputJsonRef` property of each estimator with the corresponding output from the `ScoringManagerJSON`.

### Integration into existing workflow:
* [`src/services/ShSimulatorService.tsx`](diffhunk://#diff-2179512f339e13f570cb0371ad115ca927d2e7a48929797fd97671033ae6aa05L110-R129): Modified the `recreateRefsInResults` function to use the newly added `recreateRefToScoringManagerOutputs` function before calling `recreateRefToFilters`, ensuring that the estimators have updated scoring manager outputs.