### PR TITLE
newer versions of node 14 and beyond are supported, modified package …

### DIFF
--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         operating-system: [ubuntu-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x] 
+        node-version: [22.x] 
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x] 
+        node-version: [20.x, 22.x] 
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir "poetry ~= 1.8.2" \
     && poetry build --format wheel --no-ansi
 
 # Stage 3: Build the application.
-FROM node:20 AS build
+FROM node:22 AS build
 
 # Directory where the app is installed and run.
 WORKDIR /usr/src/app

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,9 @@
 				"prettier": "3.5.3",
 				"react-app-rewired": "^2.2.1",
 				"selenium-webdriver": "^4.30.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
 	"version": "0.1.0",
 	"private": false,
 	"homepage": ".",
+	"engines": {
+		"node": ">=14.0.0"
+	},
 	"dependencies": {
 		"@emotion/css": "^11.13.5",
 		"@emotion/react": "^11.14.0",


### PR DESCRIPTION
This pull request includes several updates to the Node.js version across different files and configurations. The most important changes include updating the Node.js version in the GitHub workflows, Dockerfile, and `package.json`.

Updates to Node.js version:

* [`.github/workflows/manual_test.yml`](diffhunk://#diff-cb08d37d26dd2d11ba4235a4aff4a4fb8c49779b0f9b5c3884531244d2566d5aL20-R20): Added Node.js version 22.x to the matrix strategy.
* [`.github/workflows/node.js.yml`](diffhunk://#diff-014228303dff9a1af15f4bbd18401f906380129b10ae2a2c62f8b8be592ff88eL19-R19): Updated Node.js version to 22.x in the matrix strategy.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L30-R30): Changed the Node.js version from 20 to 22 in the build stage.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R6-R8): Added an `engines` field specifying Node.js version >=14.0.0.

Closes #1970

This PR adds support for node 22 and beyond