### PR TITLE
Remove unnecessary and unhandled promise rejections

### DIFF
--- a/src/ThreeEditor/Simulation/CustomStoppingPower/CustomStoppingPower.ts
+++ b/src/ThreeEditor/Simulation/CustomStoppingPower/CustomStoppingPower.ts
@@ -30,7 +30,7 @@ const getAvailableStoppingPowerFiles = (path: StoppingPowerTable) => {
 			if (error.code === 'MODULE_NOT_FOUND') {
 				// file not found
 			} else {
-				throw error;
+				console.log(`Error while loading stopping power files: ${error.message}`);
 			}
 		}
 	}

--- a/src/services/AuthService.tsx
+++ b/src/services/AuthService.tsx
@@ -328,13 +328,13 @@ const Auth = ({ children }: GenericContextProviderProps) => {
 	);
 
 	const refresh = useCallback(async () => {
-		if (user?.source === 'keycloak' && isAuthorized) return await tokenVerification();
+		if (user?.source === 'keycloak' && isAuthorized) return tokenVerification();
 
 		if (demoMode || !isServerReachable) {
 			setRefreshInterval(undefined);
 			setUser(null);
 
-			return Promise.reject();
+			return Promise.resolve();
 		}
 
 		try {

--- a/src/util/keycloak/KeycloakProvider.tsx
+++ b/src/util/keycloak/KeycloakProvider.tsx
@@ -1,42 +1,42 @@
-import React from "react";
-import { KeycloakInitOptions } from "keycloak-js";
-import { IAuthContextProps, keycloakContext } from "./keycloakContext";
-import type { KeycloakAuthProviderProps } from "./interfaces";
+import { KeycloakInitOptions } from 'keycloak-js';
+import React from 'react';
+
+import type { KeycloakAuthProviderProps } from './interfaces';
+import { IAuthContextProps, keycloakContext } from './keycloakContext';
 
 const defaultOptions: KeycloakInitOptions = {
-  onLoad: "check-sso",
+	onLoad: 'check-sso'
 };
 
 function createAuthProvider(AuthContext: React.Context<IAuthContextProps>) {
-  const KeycloakAuthProvider: React.FC<KeycloakAuthProviderProps> = (props) => {
-    const { client, children } = props;
-    const [initialized, setInitialized] = React.useState<boolean>(false);
+	const KeycloakAuthProvider: React.FC<KeycloakAuthProviderProps> = props => {
+		const { client, children } = props;
+		const [initialized, setInitialized] = React.useState<boolean>(false);
 
-    React.useEffect(() => {
-      const { client, initOptions } = props;
-      const initialize = () => {
-        client
-          .init({ ...defaultOptions, ...initOptions })
-          .then(() => {
-            setInitialized(true);
-          })
-          .catch((err: string) => {
-            throw new Error(err);
-          });
-      };
-      initialize();
-    }, []);
+		React.useEffect(() => {
+			const { client, initOptions } = props;
+			const initialize = () => {
+				client
+					.init({ ...defaultOptions, ...initOptions })
+					.then(() => {
+						setInitialized(true);
+					})
+					.catch(err => {
+						console.log('KeycloakAuthProvider:', err);
+					});
+			};
+			initialize();
+		}, []);
 
-    return (
-      <AuthContext.Provider value={{ initialized, client }}>
-        {children}
-      </AuthContext.Provider>
-    );
-  };
+		return (
+			<AuthContext.Provider value={{ initialized, client }}>{children}</AuthContext.Provider>
+		);
+	};
 
-  return KeycloakAuthProvider;
+	return KeycloakAuthProvider;
 }
 
 const KeycloakProvider = createAuthProvider(keycloakContext);
+
 export const KeycloakConsumer = keycloakContext.Consumer;
 export default KeycloakProvider;


### PR DESCRIPTION
The error overlay that appears on UI load is shown because of `Promise.reject()` or `throw` calls, which this PR removes.

- `Promise.reject()` in `AuthService` doesn't appear to serve any purpose so it's replaced with `resolve()`
- `throw error` in CustomStoppingPower is called when importing stopping file configs doesn't work - it is an implementation detail not to be shown to user, but I leave a `console.log()` to hopefully catch it
- `throw new Error(err)` in `KeycloakProvider` is never caught inside the component, so it is replaced with `console.log()`