### PR TITLE
unnecessary console log cleaning

### DIFF
--- a/src/ThreeEditor/Simulation/CustomStoppingPower/CustomStoppingPower.ts
+++ b/src/ThreeEditor/Simulation/CustomStoppingPower/CustomStoppingPower.ts
@@ -52,7 +52,6 @@ export const addCustomStoppingPowerTableToEditorJSON = async (editorJson: Editor
 
 	for (let key in editorJson.zoneManager.zones) {
 		const zone = editorJson.zoneManager.zones[key];
-		console.log(zone);
 
 		if (zone.materialPropertiesOverrides?.customStoppingPower && zone.customMaterial) {
 			usedStoppingPowerTables.add(zone.customMaterial.icru);

--- a/src/ThreeEditor/components/Sidebar/properties/category/ObjectMaterial.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/ObjectMaterial.tsx
@@ -191,7 +191,6 @@ export function ObjectMaterial(props: { editor: YaptideEditor; object: Object3D 
 							<ColorInput
 								value={watchedObjectMaterial?.color.getHexString() ?? '#ffffff'}
 								onChange={v => {
-									console.log(watchedObject.object);
 									editor.execute(
 										new SetMaterialColorCommand(
 											editor,


### PR DESCRIPTION
This pull request removes unnecessary `console.log` statements from the codebase to clean up debugging artifacts and improve code readability.

Code cleanup:

* [`src/ThreeEditor/Simulation/CustomStoppingPower/CustomStoppingPower.ts`](diffhunk://#diff-bcebd4d3da2e15dd65056e455f354a69d9951f3be79ed202522cef134fa38da0L55): Removed a `console.log` statement that logged the `zone` object during iteration over `editorJson.zoneManager.zones`.
* [`src/ThreeEditor/components/Sidebar/properties/category/ObjectMaterial.tsx`](diffhunk://#diff-228d3a246c7224c2fc0b42013a0d95cf511ab3df15cf6b17b7741e8698c5c515L194): Removed a `console.log` statement that logged the `watchedObject.object` during color input changes in the `ObjectMaterial` component.