### PR TITLE
add geant4 selection

### DIFF
--- a/public/examples/ex8.json
+++ b/public/examples/ex8.json
@@ -5,7 +5,7 @@
 		"generator": "YaptideEditor.toJSON"
 	},
 	"project": {
-		"title": "Empty Geant 4 project",
+		"title": "Empty Geant4 project",
 		"description": "Blank project for Geant4",
 		"viewManager": {
 			"ViewPanelXY": {
@@ -191,12 +191,6 @@
 		},
 		"sourceType": "simple"
 	},
-	"physic": {
-		"energyLoss": 0.03,
-		"enableNuclearReactions": true,
-		"energyModelStraggling": "Vavilov",
-		"multipleScattering": "Moliere",
-		"stoppingPowerTable": "ICRU91"
-	},
+	"physic": {},
 	"hash": "81712c541925e171dbc37106d513d25eb2988bc2"
 }

--- a/public/examples/ex8.json
+++ b/public/examples/ex8.json
@@ -1,0 +1,202 @@
+{
+	"metadata": {
+		"version": "0.12",
+		"type": "Editor",
+		"generator": "YaptideEditor.toJSON"
+	},
+	"project": {
+		"title": "Empty Geant 4 project",
+		"description": "Blank project for Geant4",
+		"viewManager": {
+			"ViewPanelXY": {
+				"cameraMatrix": [
+					1, 0, 0, 0, 0, 0.9999999999994962, 9.999999998910846e-7, 0, 0,
+					-9.999999998910846e-7, 0.9999999999994962, 0, 0, -0.0000999999999891088,
+					99.99999999994995, 1
+				],
+				"clipPlane": {
+					"planeConstant": 0,
+					"visible": true
+				}
+			},
+			"ViewPanel3D": {
+				"cameraMatrix": [
+					0.7071067811865476, 2.775557561562891e-17, -0.7071067811865472, 0,
+					-0.4082482904638628, 0.8164965809277258, -0.40824829046386285, 0,
+					0.5773502691896251, 0.5773502691896251, 0.5773502691896254, 0,
+					10.000000000000002, 10, 10.000000000000002, 1
+				]
+			},
+			"ViewPanelY": {
+				"cameraMatrix": [
+					2.2204460492502352e-16, -5.551115123125588e-17, 0.9999999999999649, 0,
+					0.9999999999994632, 0.0000010000000000287188, -1.6653345369376737e-16, 0,
+					-9.999999999732077e-7, 0.9999999999994632, 1.1102230246251157e-16, 0,
+					-0.00009999999999998334, 99.99999999994999, 6.1232339957357454e-21, 1
+				],
+				"clipPlane": {
+					"planeConstant": 0,
+					"visible": true
+				}
+			},
+			"ViewPanelX": {
+				"cameraMatrix": [
+					-2.2204460492503146e-16, 1.0000000000000007, 1.4210854715202014e-10, 0,
+					9.99999999917731e-7, -1.421085471520197e-10, 0.9999999999994976, 0,
+					0.9999999999994976, 2.775557561562885e-16, -9.99999999917731e-7, 0,
+					99.99999999994995, 1.4210854715202004e-14, -0.00009999999999998331, 1
+				],
+				"clipPlane": {
+					"planeConstant": 0,
+					"visible": true
+				}
+			},
+			"ViewPanel": {
+				"cameraMatrix": [
+					0.07426714888874009, 0, 0.9972383820310657, 0, 0.1890359579236641,
+					0.9818692455756362, -0.014078039800121761, 0, -0.9791576978239105,
+					0.18955944870338465, 0.07292062945044075, 0, -27.694761919291807,
+					5.361550864645869, 2.0625068629119263, 1
+				]
+			}
+		},
+		"history": {
+			"undos": [],
+			"redos": []
+		},
+		"simulator": "geant4"
+	},
+	"figureManager": {
+		"uuid": "0F0F0F0F-0F0F-0F0F-0F0F-0F0F0F0F0F0F",
+		"name": "Figure Manager",
+		"type": "FigureManager",
+		"metadata": {
+			"version": "0.12",
+			"type": "Manager",
+			"generator": "FigureManager.toJSON"
+		},
+		"figures": []
+	},
+	"zoneManager": {
+		"uuid": "368269D3-6F9B-4241-84A0-5D908D10E196",
+		"name": "Zone Manager",
+		"type": "ZoneManager",
+		"metadata": {
+			"version": "0.12",
+			"type": "Manager",
+			"generator": "ZoneManager.toJSON"
+		},
+		"zones": [],
+		"worldZone": {
+			"uuid": "94339b4f-7588-4bc5-b1ce-03beecd5f9c2",
+			"type": "WorldZone",
+			"name": "World Zone",
+			"marginMultiplier": 1.1,
+			"autoCalculate": false,
+			"materialUuid": "ef2115b8-1502-4f62-a033-21b06b066862",
+			"visible": false,
+			"geometryData": {
+				"geometryType": "BoxGeometry",
+				"position": [0, 0, 10.5],
+				"rotation": [0, 0, 0],
+				"parameters": {
+					"width": 0,
+					"height": 0,
+					"depth": 0
+				}
+			}
+		}
+	},
+	"detectorManager": {
+		"uuid": "9A7D17B8-BAE4-441F-965F-490CAA617EC6",
+		"name": "Detector Manager",
+		"type": "DetectorManager",
+		"metadata": {
+			"version": "0.12",
+			"type": "Manager",
+			"generator": "DetectorManager.toJSON"
+		},
+		"detectors": []
+	},
+	"specialComponentsManager": {
+		"uuid": "0F0F0F0F-0F0F-0F0F-0F0F-0F0F0F0F0FFF",
+		"name": "Special Components",
+		"type": "SpecialComponentManager",
+		"metadata": {
+			"version": "0.12",
+			"type": "Manager",
+			"generator": "SpecialComponentManager.toJSON"
+		}
+	},
+	"materialManager": {
+		"uuid": "0F0F0F0F-0F0F-0F0F-0F0F-0F0F0FFFFFFF",
+		"name": "Material Manager",
+		"type": "MaterialManager",
+		"materials": [],
+		"selectedMaterials": {},
+		"metadata": {
+			"version": "0.12",
+			"type": "Manager",
+			"generator": "MaterialManager.toJSON"
+		}
+	},
+	"scoringManager": {
+		"name": "Scoring Manager",
+		"type": "ScoringManager",
+		"uuid": "D0F67F59-F311-4F8E-A06F-5A07D618FDE2",
+		"outputs": [],
+		"filters": [],
+		"metadata": {
+			"version": "0.12",
+			"type": "Manager",
+			"generator": "ScoringManager.toJSON"
+		}
+	},
+	"beam": {
+		"name": "Beam",
+		"type": "Beam",
+		"uuid": "0F0F0F0F-0F0F-0F0F-0F0F-0F0F0F0FFFFF",
+		"position": [0, 0, 0],
+		"direction": [0, 0, 1],
+		"energy": 150,
+		"energySpread": 1.5,
+		"energyLowCutoff": 0,
+		"energyHighCutoff": 1000,
+		"sigma": {
+			"type": "Gaussian",
+			"x": 0,
+			"y": 0
+		},
+		"sad": {
+			"type": "none",
+			"x": 0,
+			"y": 0
+		},
+		"divergence": {
+			"x": 0,
+			"y": 0,
+			"distanceToFocal": 0
+		},
+		"particle": {
+			"id": 2,
+			"name": "Proton",
+			"a": 1,
+			"z": 1
+		},
+		"colorHex": 16776960,
+		"numberOfParticles": 10000,
+		"sourceFile": {
+			"value": "",
+			"name": ""
+		},
+		"sourceType": "simple"
+	},
+	"physic": {
+		"energyLoss": 0.03,
+		"enableNuclearReactions": true,
+		"energyModelStraggling": "Vavilov",
+		"multipleScattering": "Moliere",
+		"stoppingPowerTable": "ICRU91"
+	},
+	"hash": "81712c541925e171dbc37106d513d25eb2988bc2"
+}

--- a/src/ThreeEditor/Simulation/Scoring/ScoringOutputTypes.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringOutputTypes.ts
@@ -578,6 +578,10 @@ export const SCORING_OPTIONS: IScoringOptions = {
 				modifiers: new Set([])
 			}
 		}
+	},
+	[SimulatorType.GEANT4]: {
+		DETECTOR: {},
+		ZONE: {}
 	}
 };
 

--- a/src/ThreeEditor/components/Sidebar/EditorSidebar.tsx
+++ b/src/ThreeEditor/components/Sidebar/EditorSidebar.tsx
@@ -105,7 +105,8 @@ export function EditorSidebar(props: EditorSidebarProps) {
 	const simulatorDescriptions = {
 		[SimulatorType.COMMON]: 'Common options for Fluka and SHIELD-HIT12A',
 		[SimulatorType.FLUKA]: 'Fluka specific options',
-		[SimulatorType.SHIELDHIT]: 'SHIELD-HIT12A specific options'
+		[SimulatorType.SHIELDHIT]: 'SHIELD-HIT12A specific options',
+		[SimulatorType.GEANT4]: 'Geant4 specific options'
 	};
 
 	return (

--- a/src/ThreeEditor/components/Sidebar/EditorSidebar.tsx
+++ b/src/ThreeEditor/components/Sidebar/EditorSidebar.tsx
@@ -341,6 +341,19 @@ function getGeometryTabElements(simulator: SimulatorType, btnProps: any, editor:
 	];
 	const flukaElements = [...commonElements];
 
+	const geant4Elements = [
+		{
+			title: 'Geant 4 Placeholder',
+			add: btnProps['Filters'], // just for mockup
+			tree: (
+				<SidebarTree
+					editor={editor}
+					sources={[editor.figureManager.figureContainer]}
+				/>
+			)
+		}
+	];
+
 	switch (simulator) {
 		case SimulatorType.SHIELDHIT:
 			return shieldhitElements;
@@ -348,6 +361,8 @@ function getGeometryTabElements(simulator: SimulatorType, btnProps: any, editor:
 			return flukaElements;
 		case SimulatorType.COMMON:
 			return commonElements;
+		case SimulatorType.GEANT4:
+			return geant4Elements;
 		default:
 			return [];
 	}
@@ -379,6 +394,19 @@ function getScoringTabElements(simulator: SimulatorType, btnProps: any, editor: 
 	const shieldhitElements = [...commonElements];
 	const flukaElements = [...commonElements];
 
+	const geant4Elements = [
+		{
+			title: 'Geant 4 Placeholder',
+			add: btnProps['Filters'], // just for mockup
+			tree: (
+				<SidebarTree
+					editor={editor}
+					sources={[editor.figureManager.figureContainer]}
+				/>
+			)
+		}
+	];
+
 	switch (simulator) {
 		case SimulatorType.SHIELDHIT:
 			return shieldhitElements;
@@ -386,6 +414,8 @@ function getScoringTabElements(simulator: SimulatorType, btnProps: any, editor: 
 			return flukaElements;
 		case SimulatorType.COMMON:
 			return commonElements;
+		case SimulatorType.GEANT4:
+			return geant4Elements;
 		default:
 			return [];
 	}

--- a/src/examples/exampleMap.json
+++ b/src/examples/exampleMap.json
@@ -11,5 +11,8 @@
 	},
 	"common": {
 		"Beam of protons with lead collimator": "ex6.json"
+	},
+	"geant4": {
+		"Empty geant4 project": "ex8.json"
 	}
 }

--- a/src/examples/exampleMap.json
+++ b/src/examples/exampleMap.json
@@ -13,6 +13,6 @@
 		"Beam of protons with lead collimator": "ex6.json"
 	},
 	"geant4": {
-		"Empty geant4 project": "ex8.json"
+		"Empty Geant4 project": "ex8.json"
 	}
 }

--- a/src/types/RequestTypes.ts
+++ b/src/types/RequestTypes.ts
@@ -18,14 +18,16 @@ export enum OrderBy {
 export enum SimulatorType {
 	COMMON = 'common',
 	SHIELDHIT = 'shieldhit',
+	FLUKA = 'fluka',
+	GEANT4 = 'geant4'
 	// Topas is not supported in current version of yaptide
 	// TOPAS = 'topas',
-	FLUKA = 'fluka'
 }
 
 export const SimulatorNames = new Map<SimulatorType, string>([
 	[SimulatorType.SHIELDHIT, 'SHIELD-HIT12A'],
-	[SimulatorType.FLUKA, 'Fluka']
+	[SimulatorType.FLUKA, 'Fluka'],
+	[SimulatorType.GEANT4, 'Geant4']
 ]);
 
 export interface SimulatorExamples {


### PR DESCRIPTION
This pull request introduces support for the Geant4 simulator in the application. The key changes include adding a new example project for Geant4, updating the simulator types and descriptions, and modifying the UI to accommodate Geant4-specific elements.

### Geant4 Support Additions:

* **New Example Project**: Added a new Geant4 example project (`ex8.json`) to the `public/examples` directory. This project includes an empty Geant4 setup with metadata, managers, and a basic beam configuration.
* **Simulator Type Update**: Added `GEANT4` to the `SimulatorType` enum and updated the `SimulatorNames` map to include "Geant4".

### UI Enhancements for Geant4:

* **Simulator Descriptions**: Updated `EditorSidebar` to include a description for Geant4-specific options.
* **Geometry and Scoring Tabs**: Added Geant4-specific placeholder elements to the geometry and scoring tabs in the sidebar. These elements include mockup buttons and a tree structure for visualization. [[1]](diffhunk://#diff-0be9ec953422f723f0fc73dafd27d63aab12c91cfb9a8f4e7f9b6dd6dc409911R344-R365) [[2]](diffhunk://#diff-0be9ec953422f723f0fc73dafd27d63aab12c91cfb9a8f4e7f9b6dd6dc409911R397-R418)

### Configuration Updates:

* **Scoring Options**: Added Geant4-specific scoring options to the `SCORING_OPTIONS` configuration.
* **Example Mapping**: Updated `exampleMap.json` to map the new Geant4 example project.