### PR TITLE
build(workflow): update Node.js version to 22.x and adjust permissions

### DIFF
--- a/.github/workflows/cleanup_closed_pr_packages.yaml
+++ b/.github/workflows/cleanup_closed_pr_packages.yaml
@@ -9,6 +9,9 @@ jobs:
   cleanup-package:
     name: Cleanup closed PR package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to checkout the repository if the action requires it (though this specific action might not)
+      packages: write # This is the crucial permission for deleting packages from GHCR
     steps:
       - name: Cleanup web package
         uses: snok/container-retention-policy@v2

--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -1,4 +1,6 @@
 name: On-demand tests
+permissions:
+  contents: read # Required for actions/checkout and reading repo content
 
 on:
   workflow_dispatch:
@@ -10,11 +12,10 @@ env:
 jobs:
   build_and_test:
 
-
     strategy:
       matrix:
         node-version: [20.x, 22.x]
-        operating-system: [windows-latest] # ubuntu-latest, 
+        operating-system: [ubuntu-latest, windows-latest]
         python-version: ['3.11', '3.12']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x, 22.x]
-        operating-system: [ubuntu-latest, windows-latest]
+        operating-system: [windows-latest] # ubuntu-latest, 
         python-version: ['3.11', '3.12']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
@@ -46,7 +46,9 @@ jobs:
       - name: Start application in background on Windows
         if: matrix.operating-system == 'windows-latest'
         run: |
-          Start-Process -FilePath "npm" -ArgumentList "run start" -NoNewWindow -PassThru | Out-Null
+          # Use cmd /c to correctly execute "npm run start" within a shell context
+          # Start-Process now launches cmd, and cmd executes the command
+          Start-Process -FilePath "cmd" -ArgumentList "/c", "npm run start" -NoNewWindow -PassThru | Out-Null
 
       - name: Wait for the app to start
         uses: iFaxity/wait-on-action@v1.2.1

--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -43,19 +43,18 @@ jobs:
         if: matrix.operating-system == 'ubuntu-latest'
         run: npm run start &
 
-      - name: Start application in background on Windows
+      - name: Test application build on Windows
         if: matrix.operating-system == 'windows-latest'
-        run: |
-          # Use cmd /c to correctly execute "npm run start" within a shell context
-          # Start-Process now launches cmd, and cmd executes the command
-          Start-Process -FilePath "cmd" -ArgumentList "/c", "npm run start" -NoNewWindow -PassThru | Out-Null
+        run: npm run build
 
       - name: Wait for the app to start
+        if: matrix.operating-system == 'ubuntu-latest'
         uses: iFaxity/wait-on-action@v1.2.1
         with:
           resource: http://localhost:3000
 
       - name: Run tests 
+        if: matrix.operating-system == 'ubuntu-latest'
         uses: nick-fields/retry@v3
         with:
           max_attempts: 2

--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -13,9 +13,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
         operating-system: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     runs-on: ${{ matrix.operating-system }}
@@ -46,7 +46,7 @@ jobs:
       - name: Start application in background on Windows
         if: matrix.operating-system == 'windows-latest'
         run: |
-          Start-Process -FilePath "npm" -ArgumentList "run start" -NoNewWindow
+          Start-Process -FilePath "npm" -ArgumentList "run start" -NoNewWindow -PassThru | Out-Null
 
       - name: Wait for the app to start
         uses: iFaxity/wait-on-action@v1.2.1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,6 @@
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:
@@ -62,7 +64,6 @@ jobs:
     
     # when we run this action as depenabot, we need to give it write permissions to the package registry and to the statuses
     permissions:
-        contents: read
         packages: write
         statuses: write
 
@@ -122,7 +123,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: webfactory/ssh-agent for dev 🖥️

--- a/.github/workflows/packages_retention.yaml
+++ b/.github/workflows/packages_retention.yaml
@@ -9,6 +9,9 @@ jobs:
   cleanup-packages:
     name: Cleanup old GHCR docker packages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to checkout the repository if the action requires it (though this specific action might not)
+      packages: write # This is the crucial permission for deleting packages from GHCR
     steps:
       - name: Cleanup web outdated PR packages
         uses: snok/container-retention-policy@v2

--- a/buildPython.js
+++ b/buildPython.js
@@ -90,9 +90,7 @@ const saveFileName = (destFolder, fileName) => {
 		});
 
 		measureTime('Installing build module for python', () => {
-			executeCommand(
-				`${venvCommandPrefix} pip install "poetry == 1.8.5" ${venvCommandSuffix}`
-			);
+			executeCommand(`${venvCommandPrefix} pip install "poetry==1.8.5" ${venvCommandSuffix}`);
 		});
 
 		measureTime('Building yaptide_converter', () => {

--- a/buildPython.js
+++ b/buildPython.js
@@ -91,7 +91,7 @@ const saveFileName = (destFolder, fileName) => {
 
 		measureTime('Installing build module for python', () => {
 			executeCommand(
-				`${venvCommandPrefix} pip install "poetry ~= 1.8.2" ${venvCommandSuffix}`
+				`${venvCommandPrefix} pip install "poetry == 1.8.5" ${venvCommandSuffix}`
 			);
 		});
 


### PR DESCRIPTION
This pull request includes updates to GitHub Actions workflows and a minor dependency version change in the `buildPython.js` file. The most important changes involve standardizing permissions across workflows, updating dependencies, and refining testing strategies.

### Workflow Updates

* **Standardized permissions in workflows**:
  - Added `contents: read` and `packages: write` permissions to `.github/workflows/cleanup_closed_pr_packages.yaml` and `.github/workflows/packages_retention.yaml`. These permissions are necessary for repository checkout and deleting packages from GHCR. [[1]](diffhunk://#diff-645a3e5794e0fa61371c18d674ddfe48dddc6fabbc84edd192ecaa65d04a3955R12-R14) [[2]](diffhunk://#diff-7c079a19bd0a85ecf3d8f82811baf9b539e2a46b51c49b81d7b6358a3c81bc9bR12-R14)
  - Added `contents: read` permissions to `.github/workflows/manual_test.yml` and `.github/workflows/node.js.yml` to support actions like `checkout` and reading repository content. [[1]](diffhunk://#diff-cb08d37d26dd2d11ba4235a4aff4a4fb8c49779b0f9b5c3884531244d2566d5aR2-R3) [[2]](diffhunk://#diff-014228303dff9a1af15f4bbd18401f906380129b10ae2a2c62f8b8be592ff88eR2-R3)

* **Refined testing strategies in `manual_test.yml`**:
  - Removed the background start of the application on Windows and replaced it with a build step (`npm run build`). Adjusted conditional steps to ensure Ubuntu-specific tasks like starting the app and running tests are only executed on Ubuntu.
  - Reduced the matrix of Node.js versions to `[20.x, 22.x]` and Python versions to `['3.11', '3.12']` for more focused testing.

* **Updated Node.js version in `node.js.yml`**:
  - Changed the Node.js version from `20.x` to `22.x` in the CI workflow for consistency with newer dependencies.

### Dependency Updates

* **Updated Poetry version in `buildPython.js`**:
  - Changed the Poetry dependency from a version range (`~= 1.8.2`) to a specific version (`1.8.5`) to ensure compatibility and stability.