### PR TITLE
build: update Node.js version matrix to include 24.x

### DIFF
--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         operating-system: [ubuntu-latest, windows-latest]
         python-version: ['3.11', '3.12']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.x] 
+        node-version: [22.x, 24.x] 
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the Node.js versions used in GitHub Actions workflows to include the latest version (24.x) for testing and compatibility purposes.

Workflow updates:

* [`.github/workflows/manual_test.yml`](diffhunk://#diff-cb08d37d26dd2d11ba4235a4aff4a4fb8c49779b0f9b5c3884531244d2566d5aL17-R17): Added Node.js version 24.x to the matrix of versions tested in the manual test workflow.
* [`.github/workflows/node.js.yml`](diffhunk://#diff-014228303dff9a1af15f4bbd18401f906380129b10ae2a2c62f8b8be592ff88eL21-R21): Added Node.js version 24.x to the matrix of versions tested in the Node.js workflow.