### PR TITLE
Add scoring panel configuration for Geant4

### DIFF
--- a/src/ThreeEditor/Simulation/Physics/Beam.ts
+++ b/src/ThreeEditor/Simulation/Physics/Beam.ts
@@ -4,7 +4,7 @@ import { Line2 } from 'three/examples/jsm/lines/Line2.js';
 import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 
-import { FLUKA_PARTICLE_TYPES, Particle, PARTICLE_TYPES } from '../../../types/Particle';
+import { COMMON_PARTICLE_TYPES,FLUKA_PARTICLE_TYPES, Particle } from '../../../types/Particle';
 // Import of 'lines' from examples subfolder follows the official guidelines of threejs.editor (see https://threejs.org/docs/#manual/en/introduction/Installation)
 import { ConfigSourceFile } from '../../../types/SimulationTypes/ConfigTypes';
 import { SerializableState } from '../../js/EditorJson';
@@ -168,7 +168,7 @@ export class Beam extends SimulationElement implements SerializableState<BeamJSO
 	sourceFile: ConfigSourceFile;
 
 	get particle(): Particle {
-		return [...PARTICLE_TYPES, ...FLUKA_PARTICLE_TYPES].find(
+		return [...COMMON_PARTICLE_TYPES, ...FLUKA_PARTICLE_TYPES].find(
 			p => p.id === this.particleData.id
 		) as Particle;
 	}

--- a/src/ThreeEditor/Simulation/Scoring/CommonScoringOutput.ts
+++ b/src/ThreeEditor/Simulation/Scoring/CommonScoringOutput.ts
@@ -1,0 +1,100 @@
+import { SerializableState } from '../../js/EditorJson';
+import { YaptideEditor } from '../../js/YaptideEditor';
+import { SimulationElementJSON } from '../Base/SimulationElement';
+import { SimulationZone } from '../Base/SimulationZone';
+import { ScoringOutput } from './ScoringOutput';
+import { SCORING_TYPE_ENUM } from './ScoringOutputTypes';
+import { ScoringQuantityJSON } from './ScoringQuantity';
+
+export type CommonScoringOutputJSON = Omit<
+	SimulationElementJSON & {
+		quantities: ScoringQuantityJSON[];
+		detectorUuid?: string;
+		zoneUuid?: string;
+		scoringType?: string;
+		trace: boolean;
+		traceFilter?: string;
+	},
+	never
+>;
+
+export class CommonScoringOutput
+	extends ScoringOutput
+	implements SerializableState<CommonScoringOutputJSON>
+{
+	private _zone?: string;
+
+	private _scoringType: SCORING_TYPE_ENUM = SCORING_TYPE_ENUM.DETECTOR;
+
+	get zone(): SimulationZone | null {
+		if (!this._zone) return null;
+
+		return this.editor.zoneManager.getZoneByUuid(this._zone);
+	}
+
+	set zone(zone: SimulationZone | null) {
+		this._zone = zone?.uuid;
+		this.geometry = null;
+		this.signals.objectSelected.dispatch(this);
+	}
+
+	override get scoringType(): SCORING_TYPE_ENUM {
+		return this._scoringType ?? SCORING_TYPE_ENUM.DETECTOR;
+	}
+
+	set scoringType(scoringType: SCORING_TYPE_ENUM) {
+		this._scoringType = scoringType;
+
+		if (scoringType === SCORING_TYPE_ENUM.DETECTOR) {
+			this._zone = undefined;
+		} else if (scoringType === SCORING_TYPE_ENUM.ZONE) {
+			this._detector = undefined;
+		}
+	}
+
+	override toSerialized(): CommonScoringOutputJSON {
+		return {
+			...super.toSerialized(),
+			detectorUuid: this._detector,
+			zoneUuid: this._zone,
+			scoringType: this._scoringType
+		};
+	}
+
+	override fromSerialized(json: CommonScoringOutputJSON): this {
+		super.fromSerialized(json);
+
+		this.detector = json.detectorUuid
+			? this.editor.detectorManager.getDetectorByUuid(json.detectorUuid)
+			: null;
+		this.zone = json.zoneUuid ? this.editor.zoneManager.getZoneByUuid(json.zoneUuid) : null;
+
+		this._scoringType = (json.scoringType as SCORING_TYPE_ENUM) ?? SCORING_TYPE_ENUM.DETECTOR;
+
+		return this;
+	}
+
+	static fromSerialized(
+		editor: YaptideEditor,
+		json: CommonScoringOutputJSON
+	): CommonScoringOutput {
+		return new CommonScoringOutput(editor).fromSerialized(json);
+	}
+
+	duplicate(): CommonScoringOutput {
+		const duplicated = new CommonScoringOutput(this.editor);
+
+		duplicated.name = this.name;
+		duplicated._trace = this._trace;
+
+		duplicated.quantityContainer = this.quantityContainer.duplicate();
+		duplicated.add(duplicated.quantityContainer);
+
+		duplicated._scoringType = this._scoringType ?? SCORING_TYPE_ENUM.DETECTOR;
+
+		return duplicated;
+	}
+}
+
+export const isCommonOutput = (x: unknown): x is CommonScoringOutput =>
+	x instanceof CommonScoringOutput;

--- a/src/ThreeEditor/Simulation/Scoring/GeantScoringFilter.ts
+++ b/src/ThreeEditor/Simulation/Scoring/GeantScoringFilter.ts
@@ -1,0 +1,98 @@
+import { ParticleType } from '../../components/Select/ParticleSelect';
+import { YaptideEditor } from '../../js/YaptideEditor';
+import { SimulationElementJSON } from '../Base/SimulationElement';
+import { ParticleFilterJSON } from './ParticleFilter';
+import { ScoringFilter } from './ScoringFilter';
+
+type FilterType =
+	| 'charged'
+	| 'neutral'
+	| 'particle'
+	| 'kineticEnergy'
+	| 'particleWithKineticEnergy';
+
+type FilterData = {
+	particleTypes: ParticleType[];
+	kineticEnergyLow: number;
+	kineticEnergyHigh: number;
+	kineticEnergyUnit: string;
+};
+
+export type GeantScoringFilterJSON = Omit<
+	SimulationElementJSON & {
+		filterType: FilterType;
+		data: FilterData;
+	},
+	never
+>;
+
+function getInitialFilterData() {
+	return {
+		particleTypes: [],
+		kineticEnergyLow: 1,
+		kineticEnergyHigh: 10,
+		kineticEnergyUnit: 'MeV'
+	};
+}
+
+export function isGeantScoringFilterJSON(filter: any): filter is ParticleFilterJSON {
+	return filter && typeof filter.filterType === 'string' && typeof filter.data === 'object';
+}
+
+export class GeantScoringFilter extends ScoringFilter {
+	filterType: FilterType;
+	data: FilterData;
+
+	constructor(editor: YaptideEditor) {
+		super(editor);
+		this.filterType = 'charged';
+		this.data = getInitialFilterData();
+	}
+
+	clear(): this {
+		this.filterType = 'charged';
+		this.data = getInitialFilterData();
+		this.name = 'Filter';
+
+		return this;
+	}
+
+	toSerialized(): GeantScoringFilterJSON {
+		const { uuid, name, filterType, data, type } = this;
+
+		return { uuid, name, type, data, filterType };
+	}
+
+	fromSerialized(json: GeantScoringFilterJSON) {
+		this.clear();
+		this.uuid = json.uuid;
+		this.name = json.name;
+		this.filterType = json.filterType;
+		this.data = json.data;
+
+		return this;
+	}
+
+	static fromSerialized(editor: YaptideEditor, json: GeantScoringFilterJSON): GeantScoringFilter {
+		return new GeantScoringFilter(editor).fromSerialized(json);
+	}
+
+	toString(): string {
+		const { uuid, name, filterType } = this;
+
+		return `[${uuid}]\n${name}\n${filterType}`;
+	}
+
+	duplicate(): GeantScoringFilter {
+		const duplicated = new GeantScoringFilter(this.editor);
+
+		duplicated.name = this.name;
+		duplicated.filterType = this.filterType;
+		duplicated.data = { ...this.data };
+
+		return duplicated;
+	}
+}
+
+export const isGeantScoringFilter = (x: unknown): x is GeantScoringFilter =>
+	x instanceof GeantScoringFilter;

--- a/src/ThreeEditor/Simulation/Scoring/GeantScoringOutput.ts
+++ b/src/ThreeEditor/Simulation/Scoring/GeantScoringOutput.ts
@@ -1,0 +1,36 @@
+import { SerializableState } from '../../js/EditorJson';
+import { YaptideEditor } from '../../js/YaptideEditor';
+import { SimulationElementJSON } from '../Base/SimulationElement';
+import { ScoringOutput } from './ScoringOutput';
+import { ScoringQuantityJSON } from './ScoringQuantity';
+
+export type GeantScoringOutputJSON = Omit<
+	SimulationElementJSON & {
+		quantities: ScoringQuantityJSON[];
+		detectorUuid?: string;
+		trace: boolean;
+		traceFilter?: string;
+	},
+	never
+>;
+
+export class GeantScoringOutput
+	extends ScoringOutput
+	implements SerializableState<GeantScoringOutputJSON>
+{
+	static fromSerialized(editor: YaptideEditor, json: GeantScoringOutputJSON): GeantScoringOutput {
+		return new GeantScoringOutput(editor).fromSerialized(json);
+	}
+
+	override duplicate(): GeantScoringOutput {
+		const duplicated = new GeantScoringOutput(this.editor);
+
+		duplicated.name = this.name;
+		duplicated._trace = this._trace;
+
+		duplicated.quantityContainer = this.quantityContainer.duplicate();
+		duplicated.add(duplicated.quantityContainer);
+
+		return duplicated;
+	}
+}

--- a/src/ThreeEditor/Simulation/Scoring/GeantScoringOutput.ts
+++ b/src/ThreeEditor/Simulation/Scoring/GeantScoringOutput.ts
@@ -34,3 +34,5 @@ export class GeantScoringOutput
 		return duplicated;
 	}
 }
+export const isGeantOutput = (x: unknown): x is GeantScoringOutput =>
+	x instanceof GeantScoringOutput;

--- a/src/ThreeEditor/Simulation/Scoring/QuantityContainer.ts
+++ b/src/ThreeEditor/Simulation/Scoring/QuantityContainer.ts
@@ -1,0 +1,30 @@
+import { YaptideEditor } from '../../js/YaptideEditor';
+import { SimulationSceneContainer } from '../Base/SimulationContainer';
+import { ScoringQuantity } from './ScoringQuantity';
+
+export class QuantityContainer extends SimulationSceneContainer<ScoringQuantity> {
+	children: ScoringQuantity[];
+	readonly isQuantityContainer: true = true;
+	constructor(editor: YaptideEditor) {
+		super(editor, 'Quantities', 'QuantityGroup', json =>
+			new ScoringQuantity(editor).fromSerialized(json)
+		);
+		this.children = [];
+	}
+
+	reset() {
+		this.name = 'Quantities';
+		this.clear();
+	}
+
+	duplicate() {
+		const duplicated = new QuantityContainer(this.editor);
+
+		this.children.forEach(child => duplicated.add(child.duplicate()));
+
+		return duplicated;
+	}
+}
+
+export const isQuantityContainer = (x: unknown): x is QuantityContainer =>
+	x instanceof QuantityContainer;

--- a/src/ThreeEditor/Simulation/Scoring/ScoringFilter.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringFilter.ts
@@ -1,13 +1,12 @@
-import { json } from 'node:stream/consumers';
-
 import { SerializableState } from '../../js/EditorJson';
 import { YaptideEditor } from '../../js/YaptideEditor';
-import { SimulationElement, SimulationElementJSON } from '../Base/SimulationElement';
+import { SimulationElement } from '../Base/SimulationElement';
 import { CustomFilterJSON } from './CustomFilter';
 import { FilterRule } from './FilterRule';
+import { GeantScoringFilterJSON } from './GeantScoringFilter';
 import { ParticleFilterJSON } from './ParticleFilter';
 
-export type FilterJSON = CustomFilterJSON | ParticleFilterJSON;
+export type FilterJSON = CustomFilterJSON | ParticleFilterJSON | GeantScoringFilterJSON;
 
 export class ScoringFilter extends SimulationElement implements SerializableState<FilterJSON> {
 	readonly isFilter: true = true;

--- a/src/ThreeEditor/Simulation/Scoring/ScoringManager.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringManager.ts
@@ -6,15 +6,13 @@ import { JSON_VERSION, YaptideEditor } from '../../js/YaptideEditor';
 import { SimulationSceneContainer } from '../Base/SimulationContainer';
 import { SimulationElement, SimulationElementJSON } from '../Base/SimulationElement';
 import { SimulationElementManager } from '../Base/SimulationManager';
+import { CommonScoringOutput } from './CommonScoringOutput';
 import { CustomFilter, isCustomFilterJSON } from './CustomFilter';
-import {
-	GeantScoringFilter,
-	isGeantScoringFilter,
-	isGeantScoringFilterJSON
-} from './GeantScoringFilter';
+import { GeantScoringFilter, isGeantScoringFilterJSON } from './GeantScoringFilter';
 import { isParticleFilterJSON, ParticleFilter } from './ParticleFilter';
 import { FilterJSON, ScoringFilter } from './ScoringFilter';
 import { ScoringOutput, ScoringOutputJSON as OutputJSON } from './ScoringOutput';
+import createScoringOutput from './ScoringOutputFactory';
 import { ScoringQuantity } from './ScoringQuantity';
 
 export type ScoringManagerJSON = Omit<
@@ -27,7 +25,7 @@ export type ScoringManagerJSON = Omit<
 >;
 
 const outputLoader = (editor: YaptideEditor) => (json: OutputJSON) =>
-	new ScoringOutput(editor).fromSerialized(json);
+	createScoringOutput(editor).fromSerialized(json);
 
 export class OutputContainer extends SimulationSceneContainer<ScoringOutput> {
 	readonly isOutputContainer: true = true;
@@ -169,6 +167,7 @@ export class ScoringManager
 
 	getTakenDetectors(): string[] {
 		return this.outputs
+			.filter(obj => obj instanceof CommonScoringOutput)
 			.reduce<(string | null)[]>((acc, output) => {
 				return acc.concat(output.getTakenDetector());
 			}, [])

--- a/src/ThreeEditor/Simulation/Scoring/ScoringManager.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringManager.ts
@@ -7,6 +7,11 @@ import { SimulationSceneContainer } from '../Base/SimulationContainer';
 import { SimulationElement, SimulationElementJSON } from '../Base/SimulationElement';
 import { SimulationElementManager } from '../Base/SimulationManager';
 import { CustomFilter, isCustomFilterJSON } from './CustomFilter';
+import {
+	GeantScoringFilter,
+	isGeantScoringFilter,
+	isGeantScoringFilterJSON
+} from './GeantScoringFilter';
 import { isParticleFilterJSON, ParticleFilter } from './ParticleFilter';
 import { FilterJSON, ScoringFilter } from './ScoringFilter';
 import { ScoringOutput, ScoringOutputJSON as OutputJSON } from './ScoringOutput';
@@ -42,6 +47,8 @@ const filterLoader = (editor: YaptideEditor) => (json: FilterJSON) => {
 	if (isCustomFilterJSON(json)) return new CustomFilter(editor).fromSerialized(json);
 
 	if (isParticleFilterJSON(json)) return new ParticleFilter(editor).fromSerialized(json);
+
+	if (isGeantScoringFilterJSON(json)) return new GeantScoringFilter(editor).fromSerialized(json);
 
 	throw new Error(`Unknown filter type: ${json}`);
 };

--- a/src/ThreeEditor/Simulation/Scoring/ScoringOutput.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringOutput.ts
@@ -3,11 +3,10 @@ import * as THREE from 'three';
 
 import { SerializableState } from '../../js/EditorJson';
 import { YaptideEditor } from '../../js/YaptideEditor';
-import { SimulationSceneContainer } from '../Base/SimulationContainer';
 import { SimulationElement, SimulationElementJSON } from '../Base/SimulationElement';
 import { SimulationElementManager } from '../Base/SimulationManager';
-import { SimulationZone } from '../Base/SimulationZone';
 import { Detector } from '../Detectors/Detector';
+import { QuantityContainer } from './QuantityContainer';
 import { ScoringFilter } from './ScoringFilter';
 import { SCORING_TYPE_ENUM } from './ScoringOutputTypes';
 import { ScoringQuantity, ScoringQuantityJSON } from './ScoringQuantity';
@@ -16,39 +15,13 @@ export type ScoringOutputJSON = Omit<
 	SimulationElementJSON & {
 		quantities: ScoringQuantityJSON[];
 		detectorUuid?: string;
-		zoneUuid?: string;
-		scoringType?: string;
 		trace: boolean;
 		traceFilter?: string;
 	},
 	never
 >;
 
-export class QuantityContainer extends SimulationSceneContainer<ScoringQuantity> {
-	children: ScoringQuantity[];
-	readonly isQuantityContainer: true = true;
-	constructor(editor: YaptideEditor) {
-		super(editor, 'Quantities', 'QuantityGroup', json =>
-			new ScoringQuantity(editor).fromSerialized(json)
-		);
-		this.children = [];
-	}
-
-	reset() {
-		this.name = 'Quantities';
-		this.clear();
-	}
-
-	duplicate() {
-		const duplicated = new QuantityContainer(this.editor);
-
-		this.children.forEach(child => duplicated.add(child.duplicate()));
-
-		return duplicated;
-	}
-}
-
-export class ScoringOutput
+export abstract class ScoringOutput
 	extends SimulationElement
 	implements
 		SimulationElementManager<'quantity', ScoringQuantity, 'quantities'>,
@@ -63,18 +36,14 @@ export class ScoringOutput
 		return this._trace[0];
 	}
 
-	private signals: {
+	protected signals: {
 		objectSelected: Signal<THREE.Object3D>;
 	};
 
-	private _detector?: string;
-
-	private _zone?: string;
-
-	private _scoringType: SCORING_TYPE_ENUM = SCORING_TYPE_ENUM.DETECTOR;
+	protected _detector?: string;
 
 	//TODO: Issue#320
-	private _trace: [boolean, string | null];
+	protected _trace: [boolean, string | null];
 
 	quantityContainer: QuantityContainer;
 	geometry: THREE.BufferGeometry | null = null;
@@ -107,12 +76,6 @@ export class ScoringOutput
 		return this.editor.detectorManager.getDetectorByUuid(this._detector);
 	}
 
-	get zone(): SimulationZone | null {
-		if (!this._zone) return null;
-
-		return this.editor.zoneManager.getZoneByUuid(this._zone);
-	}
-
 	set detector(detector: Detector | null) {
 		this._detector = detector?.uuid;
 		this.geometry =
@@ -120,24 +83,8 @@ export class ScoringOutput
 		this.signals.objectSelected.dispatch(this);
 	}
 
-	set zone(zone: SimulationZone | null) {
-		this._zone = zone?.uuid;
-		this.geometry = null;
-		this.signals.objectSelected.dispatch(this);
-	}
-
 	get scoringType(): SCORING_TYPE_ENUM {
-		return this._scoringType ?? SCORING_TYPE_ENUM.DETECTOR;
-	}
-
-	set scoringType(scoringType: SCORING_TYPE_ENUM) {
-		this._scoringType = scoringType;
-
-		if (scoringType === SCORING_TYPE_ENUM.DETECTOR) {
-			this._zone = undefined;
-		} else if (scoringType === SCORING_TYPE_ENUM.ZONE) {
-			this._detector = undefined;
-		}
+		return SCORING_TYPE_ENUM.DETECTOR;
 	}
 
 	constructor(editor: YaptideEditor) {
@@ -194,8 +141,6 @@ export class ScoringOutput
 			...super.toSerialized(),
 			quantities: this.quantityContainer.toSerialized(),
 			detectorUuid: this._detector,
-			zoneUuid: this._zone,
-			scoringType: this._scoringType,
 			trace: this._trace[0],
 			...(this.trace[1] && { traceFilter: this.trace[1] })
 		};
@@ -210,33 +155,11 @@ export class ScoringOutput
 		this.detector = json.detectorUuid
 			? this.editor.detectorManager.getDetectorByUuid(json.detectorUuid)
 			: null;
-		this.zone = json.zoneUuid ? this.editor.zoneManager.getZoneByUuid(json.zoneUuid) : null;
-
-		this._scoringType = (json.scoringType as SCORING_TYPE_ENUM) ?? SCORING_TYPE_ENUM.DETECTOR;
 
 		return this;
 	}
 
-	static fromSerialized(editor: YaptideEditor, json: ScoringOutputJSON): ScoringOutput {
-		return new ScoringOutput(editor).fromSerialized(json);
-	}
-
-	duplicate(): ScoringOutput {
-		const duplicated = new ScoringOutput(this.editor);
-
-		duplicated.name = this.name;
-		duplicated._trace = this._trace;
-
-		duplicated.quantityContainer = this.quantityContainer.duplicate();
-		duplicated.add(duplicated.quantityContainer);
-
-		duplicated._scoringType = this._scoringType ?? SCORING_TYPE_ENUM.DETECTOR;
-
-		return duplicated;
-	}
+	abstract duplicate(): ScoringOutput;
 }
 
 export const isOutput = (x: unknown): x is ScoringOutput => x instanceof ScoringOutput;
-
-export const isQuantityContainer = (x: unknown): x is QuantityContainer =>
-	x instanceof QuantityContainer;

--- a/src/ThreeEditor/Simulation/Scoring/ScoringOutputFactory.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringOutputFactory.ts
@@ -1,0 +1,10 @@
+import { SimulatorType } from '../../../types/RequestTypes';
+import { YaptideEditor } from '../../js/YaptideEditor';
+import { CommonScoringOutput } from './CommonScoringOutput';
+import { GeantScoringOutput } from './GeantScoringOutput';
+
+export default function createScoringOutput(editor: YaptideEditor) {
+	return editor.contextManager.currentSimulator === SimulatorType.GEANT4
+		? new GeantScoringOutput(editor)
+		: new CommonScoringOutput(editor);
+}

--- a/src/ThreeEditor/Simulation/Scoring/ScoringOutputTypes.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringOutputTypes.ts
@@ -13,7 +13,6 @@ export enum SCORING_KEYWORD {
 	'dQ' = 'dQ',
 	'dQeff' = 'dQeff',
 	'EqvDose' = 'EqvDose',
-	'Fluence' = 'Fluence',
 	'MATERIAL' = 'MATERIAL',
 	'NEqvDose' = 'NEqvDose',
 	'NKERMA' = 'NKERMA',
@@ -29,11 +28,9 @@ export enum SCORING_KEYWORD {
 	// Geant4 + common
 	'DoseGy' = 'DoseGy',
 	'Energy' = 'Energy',
-	// Geant4 specific
-	'CellCharge' = 'cellCharge',
-	'CellFlux' = 'CellFlux',
-	'FlatSurfaceCurrent' = 'FlatSurfaceCurrent',
-	'FlatSurfaceFlux' = 'FlatSurfaceFlux'
+	'Fluence' = 'Fluence',
+	// Geant4 only
+	'KineticEnergySpectrum' = 'Fluence [/cm2] wrt. kinetic energy [MeV]'
 }
 
 export const SCORING_KEYWORD_DESCRIPTION = {
@@ -51,7 +48,6 @@ export const SCORING_KEYWORD_DESCRIPTION = {
 	'dQ': 'Dose-averaged Q',
 	'dQeff': 'Dose-averaged Qeff',
 	'EqvDose': 'Equivalent dose (see notes below) [Sv]',
-	'Fluence': 'Fluence [/cm2]',
 	'MATERIAL': 'Maps material ID as assigned in geo.dat. Useful for debugging geometries.',
 	'NEqvDose': 'Equivalent dose from neutron kerma (see notes below) [Sv]',
 	'NKERMA': 'Neutron Kerma in [Gy]',
@@ -67,11 +63,9 @@ export const SCORING_KEYWORD_DESCRIPTION = {
 	// Geant4 + common
 	'DoseGy': 'Dose [Gy]',
 	'Energy': 'Total amount of energy deposited [MeV]',
-	// Geant4 specific
-	'CellCharge': 'Deposited charge in the volume',
-	'CellFlux': 'Sum of track length divided by the volume[MeV]',
-	'FlatSurfaceCurrent': 'Surface current on -z surface to be used only for Box [MeV]',
-	'FlatSurfaceFlux': 'Surface flux (1/cos(theta)) on -z surface to be used only for Box [MeV]'
+	'Fluence': 'Fluence [/cm2]',
+	// Geant4 only
+	'KineticEnergySpectrum': 'Fluence [/cm2] wrt. kinetic energy [MeV]'
 } as const;
 
 export enum SCORING_MODIFIERS {
@@ -597,10 +591,8 @@ export const SCORING_OPTIONS: IScoringOptions = {
 		DETECTOR: {
 			DoseGy: { configuration: new Set([]), modifiers: new Set([]) },
 			Energy: { configuration: new Set([]), modifiers: new Set([]) },
-			CellCharge: { configuration: new Set([]), modifiers: new Set([]) },
-			CellFlux: { configuration: new Set([]), modifiers: new Set([]) },
-			FlatSurfaceCurrent: { configuration: new Set([]), modifiers: new Set([]) },
-			FlatSurfaceFlux: { configuration: new Set([]), modifiers: new Set([]) }
+			Fluence: { configuration: new Set([]), modifiers: new Set([]) },
+			KineticEnergySpectrum: { configuration: new Set([]), modifiers: new Set([]) }
 		}
 	}
 };

--- a/src/ThreeEditor/Simulation/Scoring/ScoringOutputTypes.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringOutputTypes.ts
@@ -30,7 +30,7 @@ export enum SCORING_KEYWORD {
 	'Energy' = 'Energy',
 	'Fluence' = 'Fluence',
 	// Geant4 only
-	'KineticEnergySpectrum' = 'Fluence [/cm2] wrt. kinetic energy [MeV]'
+	'KineticEnergySpectrum' = 'KineticEnergySpectrum'
 }
 
 export const SCORING_KEYWORD_DESCRIPTION = {

--- a/src/ThreeEditor/Simulation/Scoring/ScoringOutputTypes.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringOutputTypes.ts
@@ -1,6 +1,7 @@
 import { SimulatorType } from '../../../types/RequestTypes';
 
 export enum SCORING_KEYWORD {
+	// common
 	'1MeVNEq' = '1MeVNEq',
 	'Alanine' = 'Alanine',
 	'AvgBeta' = 'AvgBeta',
@@ -8,11 +9,9 @@ export enum SCORING_KEYWORD {
 	'Dose' = 'Dose',
 	'DoseEqv' = 'DoseEqv',
 	'DDD' = 'DDD',
-	'DoseGy' = 'DoseGy',
 	'dLET' = 'dLET',
 	'dQ' = 'dQ',
 	'dQeff' = 'dQeff',
-	'Energy' = 'Energy',
 	'EqvDose' = 'EqvDose',
 	'Fluence' = 'Fluence',
 	'MATERIAL' = 'MATERIAL',
@@ -26,10 +25,19 @@ export enum SCORING_KEYWORD {
 	'dZ2Beta2' = 'dZ2Beta2',
 	'tZ2Beta2' = 'tZ2Beta2',
 	'dZeff2Beta2' = 'dZeff2Beta2',
-	'tZeff2Beta2' = 'tZeff2Beta2'
+	'tZeff2Beta2' = 'tZeff2Beta2',
+	// Geant4 + common
+	'DoseGy' = 'DoseGy',
+	'Energy' = 'Energy',
+	// Geant4 specific
+	'CellCharge' = 'cellCharge',
+	'CellFlux' = 'CellFlux',
+	'FlatSurfaceCurrent' = 'FlatSurfaceCurrent',
+	'FlatSurfaceFlux' = 'FlatSurfaceFlux'
 }
 
 export const SCORING_KEYWORD_DESCRIPTION = {
+	// common
 	'1MeVNEq':
 		'1-MeV neutron equivalent fluence [cm−2]. Only scored for neutrons, protons and pions.Multiply with 2.037e-3 to get DNIEL in [MeV / g]',
 	'Alanine':
@@ -39,11 +47,9 @@ export const SCORING_KEYWORD_DESCRIPTION = {
 	'Dose': 'Dose [MeV/g]',
 	'DoseEqv': 'Dose-Equivalent (see notes below) [Sv]',
 	'DDD': 'as Dose, but specially for TRiP98 depth-dose kernel file generation',
-	'DoseGy': 'Dose [Gy]',
 	'dLET': 'Dose-averaged LET [MeV/cm]',
 	'dQ': 'Dose-averaged Q',
 	'dQeff': 'Dose-averaged Qeff',
-	'Energy': 'Total amount of energy deposited [MeV]',
 	'EqvDose': 'Equivalent dose (see notes below) [Sv]',
 	'Fluence': 'Fluence [/cm2]',
 	'MATERIAL': 'Maps material ID as assigned in geo.dat. Useful for debugging geometries.',
@@ -57,7 +63,15 @@ export const SCORING_KEYWORD_DESCRIPTION = {
 	'dZ2Beta2': 'Dose-averaged Z²/beta²',
 	'tZ2Beta2': 'Track-averaged Z²/beta²',
 	'dZeff2Beta2': 'Dose-averaged Zeff²/beta²',
-	'tZeff2Beta2': 'Track-averaged Zeff²/beta²'
+	'tZeff2Beta2': 'Track-averaged Zeff²/beta²',
+	// Geant4 + common
+	'DoseGy': 'Dose [Gy]',
+	'Energy': 'Total amount of energy deposited [MeV]',
+	// Geant4 specific
+	'CellCharge': 'Deposited charge in the volume',
+	'CellFlux': 'Sum of track length divided by the volume[MeV]',
+	'FlatSurfaceCurrent': 'Surface current on -z surface to be used only for Box [MeV]',
+	'FlatSurfaceFlux': 'Surface flux (1/cos(theta)) on -z surface to be used only for Box [MeV]'
 } as const;
 
 export enum SCORING_MODIFIERS {
@@ -580,8 +594,14 @@ export const SCORING_OPTIONS: IScoringOptions = {
 		}
 	},
 	[SimulatorType.GEANT4]: {
-		DETECTOR: {},
-		ZONE: {}
+		DETECTOR: {
+			DoseGy: { configuration: new Set([]), modifiers: new Set([]) },
+			Energy: { configuration: new Set([]), modifiers: new Set([]) },
+			CellCharge: { configuration: new Set([]), modifiers: new Set([]) },
+			CellFlux: { configuration: new Set([]), modifiers: new Set([]) },
+			FlatSurfaceCurrent: { configuration: new Set([]), modifiers: new Set([]) },
+			FlatSurfaceFlux: { configuration: new Set([]), modifiers: new Set([]) }
+		}
 	}
 };
 

--- a/src/ThreeEditor/Simulation/Scoring/ScoringQuantity.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringQuantity.ts
@@ -58,6 +58,13 @@ export class ScoringQuantity
 	hasMaterial?: boolean;
 	material?: SimulationMaterial | undefined;
 	materialPropertiesOverrides?: OverrideMap;
+	// @see ConfigurationPresets.applyGeant4Preset
+	histogramNBins?: number;
+	histogramMin?: number;
+	histogramMax?: number;
+	histogramUnit?: string;
+	histogramXScale?: string;
+	histogramXBinScheme?: string;
 
 	addModifier(modifier: DifferentialModifier): void {
 		const modifiers = this._configurator.raw('modifiers') as ModifiersConfigurationElement;

--- a/src/ThreeEditor/Simulation/Scoring/ScoringQuantity.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringQuantity.ts
@@ -1,3 +1,4 @@
+import { SimulatorType } from '../../../types/RequestTypes';
 import { SerializableState } from '../../js/EditorJson';
 import { YaptideEditor } from '../../js/YaptideEditor';
 import { SimulationElement, SimulationElementJSON } from '../Base/SimulationElement';
@@ -7,7 +8,10 @@ import { ScoringFilter } from './ScoringFilter';
 import * as Scoring from './ScoringOutputTypes';
 import { SCORING_TYPE_ENUM } from './ScoringOutputTypes';
 import { DifferentialJSON, DifferentialModifier } from './ScoringQtyModifiers';
-import { applyShieldHitPreset } from './ScoringQuantityConfiguration/ConfigurationPresets';
+import {
+	applyGeant4Preset,
+	applyShieldHitPreset
+} from './ScoringQuantityConfiguration/ConfigurationPresets';
 import ModifiersConfigurationElement from './ScoringQuantityConfiguration/ModifiersConfigurationElement';
 import { ScoringQuantityConfigurator } from './ScoringQuantityConfiguration/ScoringQuantityConfigurator';
 
@@ -91,7 +95,12 @@ export class ScoringQuantity
 	constructor(editor: YaptideEditor) {
 		super(editor, 'Quantity', 'Quantity');
 		this._configurator = new ScoringQuantityConfigurator();
-		applyShieldHitPreset(editor, this, this._configurator);
+
+		if (editor.contextManager.currentSimulator !== SimulatorType.GEANT4) {
+			applyShieldHitPreset(editor, this, this._configurator);
+		} else {
+			applyGeant4Preset(editor, this, this._configurator);
+		}
 
 		for (const key of this._configurator.keys()) {
 			// add getters and setters for properties i.e `foo`

--- a/src/ThreeEditor/Simulation/Scoring/ScoringQuantityConfiguration/ConfigurationPresets.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringQuantityConfiguration/ConfigurationPresets.ts
@@ -61,4 +61,25 @@ export function applyGeant4Preset(
 		'keyword',
 		new BasicConfigurationElement<string>('keyword', Scoring.SCORING_KEYWORD.DoseGy)
 	);
+
+	configurator.add(
+		'histogramNBins',
+		new BasicConfigurationElement<number>('histogramNBins', 100)
+	);
+	configurator.add('histogramMin', new BasicConfigurationElement<number>('histogramMin', 0));
+	configurator.add('histogramMax', new BasicConfigurationElement<number>('histogramMax', 1000));
+	configurator.add(
+		'histogramUnit',
+		new BasicConfigurationElement<string>('histogramUnit', 'MeV')
+	);
+
+	configurator.add(
+		'histogramXScale',
+		new BasicConfigurationElement<string>('histogramXScale', 'none')
+	);
+
+	configurator.add(
+		'histogramXBinScheme',
+		new BasicConfigurationElement<string>('histogramXBinScheme', 'linear')
+	);
 }

--- a/src/ThreeEditor/Simulation/Scoring/ScoringQuantityConfiguration/ConfigurationPresets.ts
+++ b/src/ThreeEditor/Simulation/Scoring/ScoringQuantityConfiguration/ConfigurationPresets.ts
@@ -50,3 +50,15 @@ export function applyShieldHitPreset(
 	);
 	configurator.add('primaries', new PrimariesConfigurationElement(materialElement));
 }
+
+export function applyGeant4Preset(
+	editor: YaptideEditor,
+	scoringQuantity: ScoringQuantity,
+	configurator: ScoringQuantityConfigurator
+) {
+	configurator.add('filter', new FilterConfigurationElement(editor));
+	configurator.add(
+		'keyword',
+		new BasicConfigurationElement<string>('keyword', Scoring.SCORING_KEYWORD.DoseGy)
+	);
+}

--- a/src/ThreeEditor/components/Dialog/ChangeScoringTypeDialog.tsx
+++ b/src/ThreeEditor/components/Dialog/ChangeScoringTypeDialog.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mui/material';
 
 import { StoreContext } from '../../../services/StoreService';
-import { ScoringOutput } from '../../Simulation/Scoring/ScoringOutput';
+import { CommonScoringOutput } from '../../Simulation/Scoring/CommonScoringOutput';
 import { SCORING_TYPE_ENUM } from '../../Simulation/Scoring/ScoringOutputTypes';
 import { ConcreteDialogProps, CustomDialog } from './CustomDialog';
 
@@ -12,7 +12,7 @@ export function ChangeScoringTypeDialog({
 	newAlignment,
 	setScoringType
 }: ConcreteDialogProps<
-	Required<Pick<StoreContext, 'yaptideEditor'>> & { scoringOutput: ScoringOutput } & {
+	Required<Pick<StoreContext, 'yaptideEditor'>> & { scoringOutput: CommonScoringOutput } & {
 		newAlignment: SCORING_TYPE_ENUM;
 	} & { setScoringType: (scoringType: SCORING_TYPE_ENUM) => void }
 >) {

--- a/src/ThreeEditor/components/Sidebar/EditorSidebar.tsx
+++ b/src/ThreeEditor/components/Sidebar/EditorSidebar.tsx
@@ -433,12 +433,12 @@ function getScoringTabElements(simulator: SimulatorType, btnProps: any, editor: 
 
 	const geant4Elements = [
 		{
-			title: 'Geant 4 Placeholder',
-			add: btnProps['Filters'], // just for mockup
+			title: 'Filters',
+			add: btnProps['Filters'],
 			tree: (
 				<SidebarTreeList
 					editor={editor}
-					sources={[editor.figureManager.figureContainer]}
+					sources={[editor.scoringManager.filterContainer]}
 				/>
 			)
 		}

--- a/src/ThreeEditor/components/Sidebar/EditorSidebar.tsx
+++ b/src/ThreeEditor/components/Sidebar/EditorSidebar.tsx
@@ -430,19 +430,7 @@ function getScoringTabElements(simulator: SimulatorType, btnProps: any, editor: 
 	];
 	const shieldhitElements = [...commonElements];
 	const flukaElements = [...commonElements];
-
-	const geant4Elements = [
-		{
-			title: 'Filters',
-			add: btnProps['Filters'],
-			tree: (
-				<SidebarTreeList
-					editor={editor}
-					sources={[editor.scoringManager.filterContainer]}
-				/>
-			)
-		}
-	];
+	const geant4Elements = [...commonElements];
 
 	switch (simulator) {
 		case SimulatorType.SHIELDHIT:

--- a/src/ThreeEditor/components/Sidebar/properties/PropertiesPanel.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/PropertiesPanel.tsx
@@ -6,15 +6,16 @@ import { Object3D } from 'three';
 import { useSignal } from '../../../../util/hooks/signals';
 import { YaptideEditor } from '../../../js/YaptideEditor';
 import { BeamConfiguration } from './category/BeamConfiguration';
+import { CommonOutputConfiguration } from './category/CommonOutputConfiguration';
 import { CustomFilterConfiguration } from './category/CustomFilterConfiguration';
 import { DetectorGrid } from './category/DetectorGrid';
+import { GeantOutputConfiguration } from './category/GeantOutputConfiguration';
 import { GeantScoringFilterConfiguration } from './category/GeantScoringFilterConfiguration';
 import { ObjectConfiguration } from './category/ObjectConfiguration';
 import { ObjectDimensions } from './category/ObjectDimensions';
 import { ObjectInfo } from './category/ObjectInfo';
 import { ObjectMaterial } from './category/ObjectMaterial';
 import { ObjectPlacement } from './category/ObjectPlacement';
-import { OutputConfiguration } from './category/OutputConfiguration';
 import { ParticleFilterConfiguration } from './category/ParticleFilterConfiguration';
 import { QuantityConfiguration } from './category/QuantityConfiguration';
 import { QuantityDifferentialScoring } from './category/QuantityDifferentialScoring';
@@ -42,7 +43,8 @@ export function PropertiesPanel(props: { boxProps: BoxProps; editor: YaptideEdit
 					<CustomFilterConfiguration {...panelProps} />
 					<ParticleFilterConfiguration {...panelProps} />
 					<GeantScoringFilterConfiguration {...panelProps} />
-					<OutputConfiguration {...panelProps} />
+					<CommonOutputConfiguration {...panelProps} />
+					<GeantOutputConfiguration {...panelProps} />
 					<QuantityConfiguration {...panelProps} />
 					<QuantityDifferentialScoring {...panelProps} />
 					<BeamConfiguration {...panelProps} />

--- a/src/ThreeEditor/components/Sidebar/properties/PropertiesPanel.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/PropertiesPanel.tsx
@@ -9,6 +9,7 @@ import { BeamConfiguration } from './category/BeamConfiguration';
 import { CommonOutputConfiguration } from './category/CommonOutputConfiguration';
 import { CustomFilterConfiguration } from './category/CustomFilterConfiguration';
 import { DetectorGrid } from './category/DetectorGrid';
+import { GeantHistogramConfiguration } from './category/GeantHistogramConfiguration';
 import { GeantOutputConfiguration } from './category/GeantOutputConfiguration';
 import { GeantScoringFilterConfiguration } from './category/GeantScoringFilterConfiguration';
 import { ObjectConfiguration } from './category/ObjectConfiguration';
@@ -54,6 +55,7 @@ export function PropertiesPanel(props: { boxProps: BoxProps; editor: YaptideEdit
 					<ZoneOperations {...panelProps} />
 					<ObjectMaterial {...panelProps} />
 					<ScoringQuantityMaterialOverrides {...panelProps} />
+					<GeantHistogramConfiguration {...panelProps} />
 				</>
 			)}
 		</Box>

--- a/src/ThreeEditor/components/Sidebar/properties/PropertiesPanel.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/PropertiesPanel.tsx
@@ -8,6 +8,7 @@ import { YaptideEditor } from '../../../js/YaptideEditor';
 import { BeamConfiguration } from './category/BeamConfiguration';
 import { CustomFilterConfiguration } from './category/CustomFilterConfiguration';
 import { DetectorGrid } from './category/DetectorGrid';
+import { GeantScoringFilterConfiguration } from './category/GeantScoringFilterConfiguration';
 import { ObjectConfiguration } from './category/ObjectConfiguration';
 import { ObjectDimensions } from './category/ObjectDimensions';
 import { ObjectInfo } from './category/ObjectInfo';
@@ -40,6 +41,7 @@ export function PropertiesPanel(props: { boxProps: BoxProps; editor: YaptideEdit
 					<ObjectPlacement {...panelProps} />
 					<CustomFilterConfiguration {...panelProps} />
 					<ParticleFilterConfiguration {...panelProps} />
+					<GeantScoringFilterConfiguration {...panelProps} />
 					<OutputConfiguration {...panelProps} />
 					<QuantityConfiguration {...panelProps} />
 					<QuantityDifferentialScoring {...panelProps} />

--- a/src/ThreeEditor/components/Sidebar/properties/category/BeamConfiguration.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/BeamConfiguration.tsx
@@ -2,7 +2,7 @@ import { Divider, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { useEffect } from 'react';
 import { Object3D } from 'three';
 
-import { FLUKA_PARTICLE_TYPES,PARTICLE_TYPES } from '../../../../../types/Particle';
+import { COMMON_PARTICLE_TYPES,FLUKA_PARTICLE_TYPES } from '../../../../../types/Particle';
 import { SimulatorType } from '../../../../../types/RequestTypes';
 import { useSmartWatchEditorState } from '../../../../../util/hooks/signals';
 import { SetValueCommand } from '../../../../js/commands/SetValueCommand';
@@ -149,7 +149,7 @@ function BeamSadField(props: { beam: Beam; onChange: (value: Beam['sad']) => voi
 function BeamConfigurationFields(props: { editor: YaptideEditor; object: Beam }) {
 	const { object, editor } = props;
 
-	let supportedParticles: ParticleType[] = [...PARTICLE_TYPES];
+	let supportedParticles: ParticleType[] = [...COMMON_PARTICLE_TYPES];
 
 	if (editor.contextManager.currentSimulator === SimulatorType.FLUKA) {
 		supportedParticles.push(...FLUKA_PARTICLE_TYPES);

--- a/src/ThreeEditor/components/Sidebar/properties/category/BeamConfiguration.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/BeamConfiguration.tsx
@@ -2,7 +2,7 @@ import { Divider, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { useEffect } from 'react';
 import { Object3D } from 'three';
 
-import { COMMON_PARTICLE_TYPES,FLUKA_PARTICLE_TYPES } from '../../../../../types/Particle';
+import { COMMON_PARTICLE_TYPES, FLUKA_PARTICLE_TYPES } from '../../../../../types/Particle';
 import { SimulatorType } from '../../../../../types/RequestTypes';
 import { useSmartWatchEditorState } from '../../../../../util/hooks/signals';
 import { SetValueCommand } from '../../../../js/commands/SetValueCommand';

--- a/src/ThreeEditor/components/Sidebar/properties/category/CommonOutputConfiguration.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/CommonOutputConfiguration.tsx
@@ -3,12 +3,14 @@ import { useCallback, useEffect, useState } from 'react';
 import { Object3D } from 'three';
 
 import { useDialog } from '../../../../../services/DialogService';
-import { SimulatorType } from '../../../../../types/RequestTypes';
 import { useSmartWatchEditorState } from '../../../../../util/hooks/signals';
 import { AddQuantityCommand } from '../../../../js/commands/AddQuantityCommand';
 import { SetOutputSettingsCommand } from '../../../../js/commands/SetOutputSettingsCommand';
 import { YaptideEditor } from '../../../../js/YaptideEditor';
-import { isOutput, ScoringOutput } from '../../../../Simulation/Scoring/ScoringOutput';
+import {
+	CommonScoringOutput,
+	isCommonOutput
+} from '../../../../Simulation/Scoring/CommonScoringOutput';
 import { SCORING_TYPE_ENUM } from '../../../../Simulation/Scoring/ScoringOutputTypes';
 import {
 	ObjectSelectOptionType,
@@ -17,12 +19,12 @@ import {
 import { PropertyField } from '../fields/PropertyField';
 import { PropertiesCategory } from './PropertiesCategory';
 
-export function OutputConfiguration(props: { editor: YaptideEditor; object: Object3D }) {
+export function CommonOutputConfiguration(props: { editor: YaptideEditor; object: Object3D }) {
 	const { object, editor } = props;
 	const { open: changeScoringType } = useDialog('changeScoringType');
 	const { state: watchedObject } = useSmartWatchEditorState(
 		editor,
-		object as unknown as ScoringOutput
+		object as unknown as CommonScoringOutput
 	);
 
 	const [scoringType, setScoringType] = useState(
@@ -85,7 +87,7 @@ export function OutputConfiguration(props: { editor: YaptideEditor; object: Obje
 		}
 	};
 
-	const visibleFlag = isOutput(watchedObject);
+	const visibleFlag = isCommonOutput(watchedObject);
 
 	return (
 		<PropertiesCategory

--- a/src/ThreeEditor/components/Sidebar/properties/category/GeantHistogramConfiguration.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/GeantHistogramConfiguration.tsx
@@ -1,0 +1,114 @@
+import { MenuItem, Select } from '@mui/material';
+import { Object3D } from 'three';
+
+import { SimulatorType } from '../../../../../types/RequestTypes';
+import { useSmartWatchEditorState } from '../../../../../util/hooks/signals';
+import { SetQuantityValueCommand } from '../../../../js/commands/SetQuantityValueCommand';
+import { YaptideEditor } from '../../../../js/YaptideEditor';
+import { isScoringQuantity, ScoringQuantity } from '../../../../Simulation/Scoring/ScoringQuantity';
+import { NumberPropertyField, PropertyField } from '../fields/PropertyField';
+import { PropertiesCategory } from './PropertiesCategory';
+
+const kineticEnergyUnits = ['meV', 'eV', 'keV', 'MeV', 'GeV'];
+
+const xAxisScaleOptions = ['none', 'log', 'log10', 'exp'];
+
+const xAxisBinSchemeOptions = ['linear', 'log'];
+
+export function GeantHistogramConfiguration(props: { editor: YaptideEditor; object: Object3D }) {
+	const { object, editor } = props;
+	const { state: watchedObject } = useSmartWatchEditorState(
+		editor,
+		object as unknown as ScoringQuantity
+	);
+
+	const visibleFlag =
+		isScoringQuantity(watchedObject) &&
+		editor.contextManager.currentSimulator == SimulatorType.GEANT4;
+
+	const setQuantityValue = (key: keyof ScoringQuantity, value: unknown) => {
+		editor.execute(new SetQuantityValueCommand(editor, watchedObject.object, key, value));
+	};
+
+	return (
+		<PropertiesCategory
+			category='Histogram'
+			visible={visibleFlag}>
+			{visibleFlag && (
+				<>
+					<NumberPropertyField
+						label='Number of bins'
+						precision={0}
+						step={1}
+						value={watchedObject.histogramNBins!}
+						onChange={v => setQuantityValue('histogramNBins', v)}
+					/>
+					<NumberPropertyField
+						label='Low'
+						value={watchedObject.histogramMin!}
+						onChange={v => setQuantityValue('histogramMin', v)}
+					/>
+					<NumberPropertyField
+						label='High'
+						value={watchedObject.histogramMax!}
+						onChange={v => setQuantityValue('histogramMax', v)}
+					/>
+					<PropertyField label='Unit'>
+						<Select
+							variant={'standard'}
+							sx={{ width: '100%' }}
+							size='small'
+							value={watchedObject.histogramUnit!}
+							onChange={event =>
+								setQuantityValue('histogramUnit', event.target.value)
+							}>
+							{kineticEnergyUnits.map(unit => (
+								<MenuItem
+									key={unit}
+									value={unit}>
+									{unit}
+								</MenuItem>
+							))}
+						</Select>
+					</PropertyField>
+					<PropertyField label='X Axis Scale'>
+						<Select
+							variant={'standard'}
+							sx={{ width: '100%' }}
+							size='small'
+							value={watchedObject.histogramXScale!}
+							onChange={event =>
+								setQuantityValue('histogramXScale', event.target.value)
+							}>
+							{xAxisScaleOptions.map(unit => (
+								<MenuItem
+									key={unit}
+									value={unit}>
+									{unit}
+								</MenuItem>
+							))}
+						</Select>
+					</PropertyField>
+					<PropertyField label='X Axis Bin Scheme'>
+						<Select
+							variant={'standard'}
+							sx={{ width: '100%' }}
+							size='small'
+							value={watchedObject.histogramXBinScheme!}
+							onChange={event =>
+								setQuantityValue('histogramXBinScheme', event.target.value)
+							}>
+							{xAxisBinSchemeOptions.map(unit => (
+								<MenuItem
+									key={unit}
+									value={unit}>
+									{unit}
+								</MenuItem>
+							))}
+						</Select>
+					</PropertyField>
+				</>
+			)}
+		</PropertiesCategory>
+	);
+}

--- a/src/ThreeEditor/components/Sidebar/properties/category/GeantOutputConfiguration.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/GeantOutputConfiguration.tsx
@@ -1,94 +1,41 @@
-import { Button, Grid, ToggleButton, ToggleButtonGroup } from '@mui/material';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { Object3D } from 'three';
 
-import { useDialog } from '../../../../../services/DialogService';
 import { useSmartWatchEditorState } from '../../../../../util/hooks/signals';
-import { AddQuantityCommand } from '../../../../js/commands/AddQuantityCommand';
 import { SetOutputSettingsCommand } from '../../../../js/commands/SetOutputSettingsCommand';
 import { YaptideEditor } from '../../../../js/YaptideEditor';
 import {
-	CommonScoringOutput,
-	isCommonOutput
-} from '../../../../Simulation/Scoring/CommonScoringOutput';
-import { GeantScoringOutput } from '../../../../Simulation/Scoring/GeantScoringOutput';
-import { SCORING_TYPE_ENUM } from '../../../../Simulation/Scoring/ScoringOutputTypes';
+	GeantScoringOutput,
+	isGeantOutput
+} from '../../../../Simulation/Scoring/GeantScoringOutput';
 import {
 	ObjectSelectOptionType,
 	ObjectSelectPropertyField
 } from '../fields/ObjectSelectPropertyField';
-import { PropertyField } from '../fields/PropertyField';
 import { PropertiesCategory } from './PropertiesCategory';
 
 export function GeantOutputConfiguration(props: { editor: YaptideEditor; object: Object3D }) {
 	const { object, editor } = props;
-	const { open: changeScoringType } = useDialog('changeScoringType');
 	const { state: watchedObject } = useSmartWatchEditorState(
 		editor,
 		object as unknown as GeantScoringOutput
 	);
-	//
-	// const [scoringType, setScoringType] = useState(
-	// 	watchedObject.scoringType ?? SCORING_TYPE_ENUM.DETECTOR
-	// );
-	//
-	// useEffect(() => {
-	// 	// needed to properly set the scoring type, useState above is not enough
-	// 	setScoringType(watchedObject.scoringType ?? SCORING_TYPE_ENUM.DETECTOR);
-	// }, [watchedObject.scoringType]);
-	//
-	// const handleChangedDetector = useCallback(
-	// 	(v: ObjectSelectOptionType) => {
-	// 		editor.execute(
-	// 			new SetOutputSettingsCommand(
-	// 				editor,
-	// 				watchedObject.object,
-	// 				'detector',
-	// 				editor.detectorManager.getDetectorByUuid(v.uuid)
-	// 			)
-	// 		);
-	// 	},
-	// 	[editor, watchedObject]
-	// );
-	//
-	// const handleChangedZone = useCallback(
-	// 	(v: ObjectSelectOptionType) => {
-	// 		editor.execute(
-	// 			new SetOutputSettingsCommand(
-	// 				editor,
-	// 				watchedObject.object,
-	// 				'zone',
-	// 				editor.zoneManager.getZoneByUuid(v.uuid)
-	// 			)
-	// 		);
-	// 	},
-	// 	[editor, watchedObject]
-	// );
-	//
-	// const handleChangeOutputType = (
-	// 	event: React.MouseEvent<HTMLElement>,
-	// 	newAlignment: SCORING_TYPE_ENUM
-	// ) => {
-	// 	if (watchedObject.quantities.length > 0) {
-	// 		changeScoringType({
-	// 			yaptideEditor: editor,
-	// 			scoringOutput: watchedObject,
-	// 			newAlignment: newAlignment,
-	// 			setScoringType: setScoringType
-	// 		});
-	// 		setScoringType(scoringType); // required for toggle component to work properly
-	// 	} else {
-	// 		if (newAlignment === SCORING_TYPE_ENUM.ZONE) {
-	// 			setScoringType(SCORING_TYPE_ENUM.ZONE);
-	// 			watchedObject.scoringType = SCORING_TYPE_ENUM.ZONE;
-	// 		} else if (newAlignment === SCORING_TYPE_ENUM.DETECTOR) {
-	// 			setScoringType(SCORING_TYPE_ENUM.DETECTOR);
-	// 			watchedObject.scoringType = SCORING_TYPE_ENUM.DETECTOR;
-	// 		}
-	// 	}
-	// };
 
-	const visibleFlag = isCommonOutput(watchedObject);
+	const handleChangedDetector = useCallback(
+		(v: ObjectSelectOptionType) => {
+			editor.execute(
+				new SetOutputSettingsCommand(
+					editor,
+					watchedObject.object,
+					'detector',
+					editor.detectorManager.getDetectorByUuid(v.uuid)
+				)
+			);
+		},
+		[editor, watchedObject]
+	);
+
+	const visibleFlag = isGeantOutput(watchedObject);
 
 	return (
 		<PropertiesCategory
@@ -96,65 +43,17 @@ export function GeantOutputConfiguration(props: { editor: YaptideEditor; object:
 			visible={visibleFlag}>
 			{visibleFlag && (
 				<>
-					{/*<PropertyField*/}
-					{/*	label='Scoring Type'*/}
-					{/*	disabled={false}>*/}
-					{/*	<ToggleButtonGroup*/}
-					{/*		value={scoringType}*/}
-					{/*		exclusive*/}
-					{/*		onChange={handleChangeOutputType}*/}
-					{/*		aria-label='scoring type'*/}
-					{/*		size='small'>*/}
-					{/*		<ToggleButton*/}
-					{/*			value={SCORING_TYPE_ENUM.DETECTOR}*/}
-					{/*			disabled={scoringType === SCORING_TYPE_ENUM.DETECTOR}*/}
-					{/*			aria-label='left aligned'>*/}
-					{/*			Detector*/}
-					{/*		</ToggleButton>*/}
-
-					{/*		<ToggleButton*/}
-					{/*			value={SCORING_TYPE_ENUM.ZONE}*/}
-					{/*			disabled={scoringType === SCORING_TYPE_ENUM.ZONE}*/}
-					{/*			aria-label='left aligned'>*/}
-					{/*			Zone*/}
-					{/*		</ToggleButton>*/}
-					{/*	</ToggleButtonGroup>*/}
-					{/*</PropertyField>*/}
-
-					{/*{scoringType === SCORING_TYPE_ENUM.DETECTOR && (*/}
-					{/*	<ObjectSelectPropertyField*/}
-					{/*		label='Detector'*/}
-					{/*		value={watchedObject.detector?.uuid ?? ''}*/}
-					{/*		options={editor.detectorManager.getDetectorOptions(value => {*/}
-					{/*			return (*/}
-					{/*				!editor.scoringManager*/}
-					{/*					.getTakenDetectors()*/}
-					{/*					.includes(value.uuid) ||*/}
-					{/*				value.uuid === watchedObject.detector?.uuid*/}
-					{/*			);*/}
-					{/*		})}*/}
-					{/*		onChange={handleChangedDetector}*/}
-					{/*	/>*/}
-					{/*)}*/}
-
-					{/*{scoringType === SCORING_TYPE_ENUM.ZONE && (*/}
-					{/*	<ObjectSelectPropertyField*/}
-					{/*		label='Zone'*/}
-					{/*		value={watchedObject.zone?.uuid ?? ''}*/}
-					{/*		options={editor.zoneManager.getZoneOptionsForScoring()}*/}
-					{/*		onChange={handleChangedZone}*/}
-					{/*	/>*/}
-					{/*)}*/}
-					{/*<Grid size={12}>*/}
-					{/*	<Button*/}
-					{/*		sx={{ width: '100%' }}*/}
-					{/*		variant='contained'*/}
-					{/*		onClick={() =>*/}
-					{/*			editor.execute(new AddQuantityCommand(editor, watchedObject.object))*/}
-					{/*		}>*/}
-					{/*		Add new quantity*/}
-					{/*	</Button>*/}
-					{/*</Grid>*/}
+					<ObjectSelectPropertyField
+						label='Detector'
+						value={watchedObject.detector?.uuid ?? ''}
+						options={editor.detectorManager.getDetectorOptions(value => {
+							return (
+								!editor.scoringManager.getTakenDetectors().includes(value.uuid) ||
+								value.uuid === watchedObject.detector?.uuid
+							);
+						})}
+						onChange={handleChangedDetector}
+					/>
 				</>
 			)}
 		</PropertiesCategory>

--- a/src/ThreeEditor/components/Sidebar/properties/category/GeantOutputConfiguration.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/GeantOutputConfiguration.tsx
@@ -1,0 +1,162 @@
+import { Button, Grid, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+import { Object3D } from 'three';
+
+import { useDialog } from '../../../../../services/DialogService';
+import { useSmartWatchEditorState } from '../../../../../util/hooks/signals';
+import { AddQuantityCommand } from '../../../../js/commands/AddQuantityCommand';
+import { SetOutputSettingsCommand } from '../../../../js/commands/SetOutputSettingsCommand';
+import { YaptideEditor } from '../../../../js/YaptideEditor';
+import {
+	CommonScoringOutput,
+	isCommonOutput
+} from '../../../../Simulation/Scoring/CommonScoringOutput';
+import { GeantScoringOutput } from '../../../../Simulation/Scoring/GeantScoringOutput';
+import { SCORING_TYPE_ENUM } from '../../../../Simulation/Scoring/ScoringOutputTypes';
+import {
+	ObjectSelectOptionType,
+	ObjectSelectPropertyField
+} from '../fields/ObjectSelectPropertyField';
+import { PropertyField } from '../fields/PropertyField';
+import { PropertiesCategory } from './PropertiesCategory';
+
+export function GeantOutputConfiguration(props: { editor: YaptideEditor; object: Object3D }) {
+	const { object, editor } = props;
+	const { open: changeScoringType } = useDialog('changeScoringType');
+	const { state: watchedObject } = useSmartWatchEditorState(
+		editor,
+		object as unknown as GeantScoringOutput
+	);
+	//
+	// const [scoringType, setScoringType] = useState(
+	// 	watchedObject.scoringType ?? SCORING_TYPE_ENUM.DETECTOR
+	// );
+	//
+	// useEffect(() => {
+	// 	// needed to properly set the scoring type, useState above is not enough
+	// 	setScoringType(watchedObject.scoringType ?? SCORING_TYPE_ENUM.DETECTOR);
+	// }, [watchedObject.scoringType]);
+	//
+	// const handleChangedDetector = useCallback(
+	// 	(v: ObjectSelectOptionType) => {
+	// 		editor.execute(
+	// 			new SetOutputSettingsCommand(
+	// 				editor,
+	// 				watchedObject.object,
+	// 				'detector',
+	// 				editor.detectorManager.getDetectorByUuid(v.uuid)
+	// 			)
+	// 		);
+	// 	},
+	// 	[editor, watchedObject]
+	// );
+	//
+	// const handleChangedZone = useCallback(
+	// 	(v: ObjectSelectOptionType) => {
+	// 		editor.execute(
+	// 			new SetOutputSettingsCommand(
+	// 				editor,
+	// 				watchedObject.object,
+	// 				'zone',
+	// 				editor.zoneManager.getZoneByUuid(v.uuid)
+	// 			)
+	// 		);
+	// 	},
+	// 	[editor, watchedObject]
+	// );
+	//
+	// const handleChangeOutputType = (
+	// 	event: React.MouseEvent<HTMLElement>,
+	// 	newAlignment: SCORING_TYPE_ENUM
+	// ) => {
+	// 	if (watchedObject.quantities.length > 0) {
+	// 		changeScoringType({
+	// 			yaptideEditor: editor,
+	// 			scoringOutput: watchedObject,
+	// 			newAlignment: newAlignment,
+	// 			setScoringType: setScoringType
+	// 		});
+	// 		setScoringType(scoringType); // required for toggle component to work properly
+	// 	} else {
+	// 		if (newAlignment === SCORING_TYPE_ENUM.ZONE) {
+	// 			setScoringType(SCORING_TYPE_ENUM.ZONE);
+	// 			watchedObject.scoringType = SCORING_TYPE_ENUM.ZONE;
+	// 		} else if (newAlignment === SCORING_TYPE_ENUM.DETECTOR) {
+	// 			setScoringType(SCORING_TYPE_ENUM.DETECTOR);
+	// 			watchedObject.scoringType = SCORING_TYPE_ENUM.DETECTOR;
+	// 		}
+	// 	}
+	// };
+
+	const visibleFlag = isCommonOutput(watchedObject);
+
+	return (
+		<PropertiesCategory
+			category='Output Configuration'
+			visible={visibleFlag}>
+			{visibleFlag && (
+				<>
+					{/*<PropertyField*/}
+					{/*	label='Scoring Type'*/}
+					{/*	disabled={false}>*/}
+					{/*	<ToggleButtonGroup*/}
+					{/*		value={scoringType}*/}
+					{/*		exclusive*/}
+					{/*		onChange={handleChangeOutputType}*/}
+					{/*		aria-label='scoring type'*/}
+					{/*		size='small'>*/}
+					{/*		<ToggleButton*/}
+					{/*			value={SCORING_TYPE_ENUM.DETECTOR}*/}
+					{/*			disabled={scoringType === SCORING_TYPE_ENUM.DETECTOR}*/}
+					{/*			aria-label='left aligned'>*/}
+					{/*			Detector*/}
+					{/*		</ToggleButton>*/}
+
+					{/*		<ToggleButton*/}
+					{/*			value={SCORING_TYPE_ENUM.ZONE}*/}
+					{/*			disabled={scoringType === SCORING_TYPE_ENUM.ZONE}*/}
+					{/*			aria-label='left aligned'>*/}
+					{/*			Zone*/}
+					{/*		</ToggleButton>*/}
+					{/*	</ToggleButtonGroup>*/}
+					{/*</PropertyField>*/}
+
+					{/*{scoringType === SCORING_TYPE_ENUM.DETECTOR && (*/}
+					{/*	<ObjectSelectPropertyField*/}
+					{/*		label='Detector'*/}
+					{/*		value={watchedObject.detector?.uuid ?? ''}*/}
+					{/*		options={editor.detectorManager.getDetectorOptions(value => {*/}
+					{/*			return (*/}
+					{/*				!editor.scoringManager*/}
+					{/*					.getTakenDetectors()*/}
+					{/*					.includes(value.uuid) ||*/}
+					{/*				value.uuid === watchedObject.detector?.uuid*/}
+					{/*			);*/}
+					{/*		})}*/}
+					{/*		onChange={handleChangedDetector}*/}
+					{/*	/>*/}
+					{/*)}*/}
+
+					{/*{scoringType === SCORING_TYPE_ENUM.ZONE && (*/}
+					{/*	<ObjectSelectPropertyField*/}
+					{/*		label='Zone'*/}
+					{/*		value={watchedObject.zone?.uuid ?? ''}*/}
+					{/*		options={editor.zoneManager.getZoneOptionsForScoring()}*/}
+					{/*		onChange={handleChangedZone}*/}
+					{/*	/>*/}
+					{/*)}*/}
+					{/*<Grid size={12}>*/}
+					{/*	<Button*/}
+					{/*		sx={{ width: '100%' }}*/}
+					{/*		variant='contained'*/}
+					{/*		onClick={() =>*/}
+					{/*			editor.execute(new AddQuantityCommand(editor, watchedObject.object))*/}
+					{/*		}>*/}
+					{/*		Add new quantity*/}
+					{/*	</Button>*/}
+					{/*</Grid>*/}
+				</>
+			)}
+		</PropertiesCategory>
+	);
+}

--- a/src/ThreeEditor/components/Sidebar/properties/category/GeantScoringFilterConfiguration.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/GeantScoringFilterConfiguration.tsx
@@ -1,0 +1,149 @@
+import { MenuItem, Select } from '@mui/material';
+import { Object3D } from 'three';
+
+import { GEANT4_PARTICLE_TYPES } from '../../../../../types/Particle';
+import { useSmartWatchEditorState } from '../../../../../util/hooks/signals';
+import { SetValueCommand } from '../../../../js/commands/SetValueCommand';
+import { YaptideEditor } from '../../../../js/YaptideEditor';
+import {
+	GeantScoringFilter,
+	isGeantScoringFilter
+} from '../../../../Simulation/Scoring/GeantScoringFilter';
+import { NumberPropertyField, PropertyField } from '../fields/PropertyField';
+import { PropertiesCategory } from './PropertiesCategory';
+
+const filterTypeNames = [
+	'charged',
+	'neutral',
+	'particle',
+	'kineticEnergy',
+	'particleWithKineticEnergy'
+];
+
+const kineticEnergyUnits = ['meV', 'eV', 'keV', 'MeV', 'GeV'];
+
+export function GeantScoringFilterConfiguration(props: {
+	editor: YaptideEditor;
+	object: Object3D;
+}) {
+	const { object, editor } = props;
+
+	const { state: watchedObject } = useSmartWatchEditorState(editor, object as GeantScoringFilter);
+
+	const visibleFlag = isGeantScoringFilter(watchedObject);
+
+	const setValueCommand = (value: any, key: string) => {
+		editor.execute(new SetValueCommand(editor, watchedObject.object, key, value));
+	};
+
+	return (
+		<PropertiesCategory
+			category='Filter Rules'
+			visible={visibleFlag}>
+			{visibleFlag && (
+				<>
+					<PropertyField label='Type'>
+						<Select
+							sx={{ width: '100%' }}
+							size='small'
+							onChange={event => {
+								setValueCommand(event.target.value, 'filterType');
+							}}
+							variant='standard'
+							value={watchedObject.filterType}>
+							{filterTypeNames.map(name => (
+								<MenuItem
+									key={name}
+									value={name}>
+									{name}
+								</MenuItem>
+							))}
+						</Select>
+					</PropertyField>
+					{(watchedObject.filterType === 'particle' ||
+						watchedObject.filterType === 'particleWithKineticEnergy') && (
+						<PropertyField label='Particles'>
+							<Select
+								variant={'standard'}
+								sx={{ width: '100%' }}
+								size='small'
+								onChange={event => {
+									const {
+										target: { value }
+									} = event;
+
+									const particleTypes =
+										typeof value === 'string' ? value.split(',') : value;
+
+									const newData = { ...watchedObject.data, particleTypes };
+
+									setValueCommand(newData, 'data');
+								}}
+								multiple
+								value={watchedObject.data.particleTypes ?? []}>
+								{GEANT4_PARTICLE_TYPES.map(({ id, name }) => (
+									<MenuItem
+										key={id}
+										value={id}>
+										{`[${id}] ${name}`}
+									</MenuItem>
+								))}
+							</Select>
+						</PropertyField>
+					)}
+					{(watchedObject.filterType === 'kineticEnergy' ||
+						watchedObject.filterType === 'particleWithKineticEnergy') && (
+						<>
+							<NumberPropertyField
+								label='Low'
+								unit={watchedObject.data.kineticEnergyUnit}
+								value={watchedObject.data.kineticEnergyLow}
+								onChange={v =>
+									setValueCommand(
+										{ ...watchedObject.data, kineticEnergyLow: v },
+										'data'
+									)
+								}
+							/>
+							<NumberPropertyField
+								label='High'
+								unit={watchedObject.data.kineticEnergyUnit}
+								value={watchedObject.data.kineticEnergyHigh}
+								onChange={v =>
+									setValueCommand(
+										{ ...watchedObject.data, kineticEnergyHigh: v },
+										'data'
+									)
+								}
+							/>
+							<PropertyField label='Unit'>
+								<Select
+									variant={'standard'}
+									sx={{ width: '100%' }}
+									size='small'
+									value={watchedObject.data.kineticEnergyUnit}
+									onChange={event =>
+										setValueCommand(
+											{
+												...watchedObject.data,
+												kineticEnergyUnit: event.target.value
+											},
+											'data'
+										)
+									}>
+									{kineticEnergyUnits.map(unit => (
+										<MenuItem
+											key={unit}
+											value={unit}>
+											{unit}
+										</MenuItem>
+									))}
+								</Select>
+							</PropertyField>
+						</>
+					)}
+				</>
+			)}
+		</PropertiesCategory>
+	);
+}

--- a/src/ThreeEditor/components/Sidebar/properties/category/ObjectInfo.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/ObjectInfo.tsx
@@ -1,6 +1,7 @@
 import { Grid } from '@mui/material';
 import { Object3D } from 'three';
 
+import { SimulatorType } from '../../../../../types/RequestTypes';
 import { useSmartWatchEditorState } from '../../../../../util/hooks/signals';
 import { SetValueCommand } from '../../../../js/commands/SetValueCommand';
 import { YaptideEditor } from '../../../../js/YaptideEditor';
@@ -16,9 +17,11 @@ export function ObjectInfo(props: { editor: YaptideEditor; object: Object3D }) {
 
 	const visibleFlag = !isBeam(watchedObject);
 	let scoringType: string | undefined = 'unknown';
+	let showScoringType = false;
 
 	if (isScoringQuantity(watchedObject)) {
 		scoringType = (watchedObject as ScoringQuantity).getScoringType();
+		showScoringType = editor.contextManager.currentSimulator !== SimulatorType.GEANT4;
 	}
 
 	return (
@@ -41,7 +44,7 @@ export function ObjectInfo(props: { editor: YaptideEditor; object: Object3D }) {
 							);
 						}}
 					/>
-					{isScoringQuantity(watchedObject) && (
+					{showScoringType && (
 						<>
 							<Grid
 								size={4}

--- a/src/ThreeEditor/components/Sidebar/properties/category/ObjectInfo.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/ObjectInfo.tsx
@@ -5,8 +5,6 @@ import { useSmartWatchEditorState } from '../../../../../util/hooks/signals';
 import { SetValueCommand } from '../../../../js/commands/SetValueCommand';
 import { YaptideEditor } from '../../../../js/YaptideEditor';
 import { isBeam } from '../../../../Simulation/Physics/Beam';
-import { ScoringOutput } from '../../../../Simulation/Scoring/ScoringOutput';
-import { SCORING_TYPE_ENUM } from '../../../../Simulation/Scoring/ScoringOutputTypes';
 import { isScoringQuantity, ScoringQuantity } from '../../../../Simulation/Scoring/ScoringQuantity';
 import { TextPropertyField } from '../fields/PropertyField';
 import { PropertiesCategory } from './PropertiesCategory';

--- a/src/ThreeEditor/components/Sidebar/properties/category/ParticleFilterConfiguration.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/ParticleFilterConfiguration.tsx
@@ -1,6 +1,6 @@
 import { Object3D } from 'three';
 
-import { PARTICLE_TYPES } from '../../../../../types/Particle';
+import { COMMON_PARTICLE_TYPES } from '../../../../../types/Particle';
 import { useSmartWatchEditorState } from '../../../../../util/hooks/signals';
 import { SetValueCommand } from '../../../../js/commands/SetValueCommand';
 import { YaptideEditor } from '../../../../js/YaptideEditor';
@@ -30,14 +30,14 @@ export function ParticleFilterConfiguration(props: { editor: YaptideEditor; obje
 				<>
 					<ParticleSelect
 						// Ignore the Heavy ions type
-						particles={PARTICLE_TYPES.filter(p => p.id !== 25)}
+						particles={COMMON_PARTICLE_TYPES.filter(p => p.id !== 25)}
 						value={watchedObject.particleData.id}
 						onChange={(_, v) =>
 							setValueCommand(
 								{
 									...watchedObject.particleData,
 									id: v,
-									name: PARTICLE_TYPES.find(p => p.id === v)?.name
+									name: COMMON_PARTICLE_TYPES.find(p => p.id === v)?.name
 								},
 								'particleData'
 							)

--- a/src/ThreeEditor/components/Sidebar/properties/category/QuantityConfiguration.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/QuantityConfiguration.tsx
@@ -43,75 +43,87 @@ export function QuantityConfiguration(props: { editor: YaptideEditor; object: Ob
 
 	let currentSimulator = editor.contextManager.currentSimulator;
 
-	const fields = (
-		<>
+	let fields = [
+		<ObjectSelectPropertyField
+			label='Quantity type'
+			value={watchedObject.keyword!}
+			options={getQuantityTypeOptions(currentSimulator, scoringType)}
+			onChange={v => setQuantityValue('keyword', v.uuid)}
+		/>
+	];
+
+	if (
+		canChangeNKMedium(currentSimulator, scoringType, watchedObject.keyword!) &&
+		editor.contextManager.currentSimulator === SimulatorType.SHIELDHIT
+	) {
+		fields.push(
 			<ObjectSelectPropertyField
-				label='Quantity type'
-				value={watchedObject.keyword!}
-				options={getQuantityTypeOptions(currentSimulator, scoringType)}
-				onChange={v => setQuantityValue('keyword', v.uuid)}
+				label='Medium'
+				value={watchedObject.medium ?? MEDIUM_KEYWORD_OPTIONS.WATER}
+				options={MEDIUM_KEYWORD_OPTIONS}
+				onChange={v => setQuantityValue('medium', v.uuid)}
 			/>
+		);
+	}
 
-			{canChangeNKMedium(currentSimulator, scoringType, watchedObject.keyword!) &&
-				editor.contextManager.currentSimulator === SimulatorType.SHIELDHIT && (
-					<>
-						<ObjectSelectPropertyField
-							label='Medium'
-							value={watchedObject.medium ?? MEDIUM_KEYWORD_OPTIONS.WATER}
-							options={MEDIUM_KEYWORD_OPTIONS}
-							onChange={v => setQuantityValue('medium', v.uuid)}
-						/>
-					</>
-				)}
+	if (
+		canChangeMaterialMedium(currentSimulator, scoringType, watchedObject.keyword!) &&
+		editor.contextManager.currentSimulator === SimulatorType.SHIELDHIT
+	) {
+		fields.push(
+			<BooleanPropertyField
+				label='Override material'
+				value={watchedObject.hasMaterial!}
+				onChange={v => setQuantityValue('hasMaterial', v)}
+			/>
+		);
+	}
 
-			{canChangeMaterialMedium(currentSimulator, scoringType, watchedObject.keyword!) &&
-				editor.contextManager.currentSimulator === SimulatorType.SHIELDHIT && (
-					<BooleanPropertyField
-						label='Override material'
-						value={watchedObject.hasMaterial!}
-						onChange={v => setQuantityValue('hasMaterial', v)}
-					/>
-				)}
+	if (
+		canChangePrimaryMultiplier(currentSimulator, scoringType, watchedObject.keyword!) &&
+		editor.contextManager.currentSimulator === SimulatorType.SHIELDHIT
+	) {
+		fields.push(
+			<ConditionalNumberPropertyField
+				label='Primaries'
+				precision={0}
+				step={1}
+				min={0}
+				max={1000}
+				value={watchedObject.primaries!}
+				enabled={watchedObject.hasPrimaries!}
+				onChange={v => setQuantityValue('primaries', v)}
+				onChangeEnabled={v => setQuantityValue('hasPrimaries', v)}
+			/>
+		);
+	}
 
-			{canChangePrimaryMultiplier(currentSimulator, scoringType, watchedObject.keyword!) &&
-				editor.contextManager.currentSimulator === SimulatorType.SHIELDHIT && (
-					<ConditionalNumberPropertyField
-						label='Primaries'
-						precision={0}
-						step={1}
-						min={0}
-						max={1000}
-						value={watchedObject.primaries!}
-						enabled={watchedObject.hasPrimaries!}
-						onChange={v => setQuantityValue('primaries', v)}
-						onChangeEnabled={v => setQuantityValue('hasPrimaries', v)}
-					/>
-				)}
+	if (Object.keys(editor.scoringManager.getFilterOptions()).length > 0) {
+		fields.push(
+			<ConditionalObjectSelectPropertyField
+				label='Filter'
+				value={watchedObject.filter?.uuid ?? ''}
+				options={editor.scoringManager.getFilterOptions()}
+				onChange={v =>
+					setQuantityValue('filter', editor.scoringManager.getFilterByUuid(v.uuid))
+				}
+				enabled={watchedObject.hasFilter!}
+				onChangeEnabled={v => setQuantityValue('hasFilter', v)}
+			/>
+		);
+	}
 
-			{Object.keys(editor.scoringManager.getFilterOptions()).length > 0 && (
-				<ConditionalObjectSelectPropertyField
-					label='Filter'
-					value={watchedObject.filter?.uuid ?? ''}
-					options={editor.scoringManager.getFilterOptions()}
-					onChange={v =>
-						setQuantityValue('filter', editor.scoringManager.getFilterByUuid(v.uuid))
-					}
-					enabled={watchedObject.hasFilter!}
-					onChangeEnabled={v => setQuantityValue('hasFilter', v)}
-				/>
-			)}
-
-			{editor.contextManager.currentSimulator === SimulatorType.SHIELDHIT && (
-				<ConditionalNumberPropertyField
-					label='Rescale'
-					value={watchedObject.rescale!}
-					onChange={v => setQuantityValue('rescale', v)}
-					enabled={watchedObject.hasRescale!}
-					onChangeEnabled={v => setQuantityValue('hasRescale', v)}
-				/>
-			)}
-		</>
-	);
+	if (editor.contextManager.currentSimulator === SimulatorType.SHIELDHIT) {
+		fields.push(
+			<ConditionalNumberPropertyField
+				label='Rescale'
+				value={watchedObject.rescale!}
+				onChange={v => setQuantityValue('rescale', v)}
+				enabled={watchedObject.hasRescale!}
+				onChangeEnabled={v => setQuantityValue('hasRescale', v)}
+			/>
+		);
+	}
 
 	return (
 		<PropertiesCategory

--- a/src/ThreeEditor/components/Sidebar/properties/category/QuantityDifferentialScoring.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/QuantityDifferentialScoring.tsx
@@ -32,7 +32,9 @@ export function QuantityDifferentialScoring(props: { editor: YaptideEditor; obje
 		object as unknown as ScoringQuantity
 	);
 
-	const visibleFlag = isScoringQuantity(watchedObject);
+	const visibleFlag =
+		isScoringQuantity(watchedObject) &&
+		editor.contextManager.currentSimulator !== SimulatorType.GEANT4;
 	let simulatorType: SimulatorType = editor.contextManager.currentSimulator;
 	const numberOfModifiers = () => {
 		if (isScoringQuantity(watchedObject)) {

--- a/src/ThreeEditor/components/Sidebar/properties/category/ScoringQuantityMaterialOverrides.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/category/ScoringQuantityMaterialOverrides.tsx
@@ -4,22 +4,13 @@ import { Object3D } from 'three';
 
 import { SimulatorType } from '../../../../../types/RequestTypes';
 import { useSmartWatchEditorState } from '../../../../../util/hooks/signals';
-import { SetMaterialColorCommand } from '../../../../js/commands/SetMaterialColorCommand';
-import { SetMaterialValueCommand } from '../../../../js/commands/SetMaterialValueCommand';
 import { SetQuantityOverriddenMaterialCommand } from '../../../../js/commands/SetQuantityOverriddenMaterialCommand';
 import { SetValueCommand } from '../../../../js/commands/SetValueCommand';
-import { SetZoneMaterialCommand } from '../../../../js/commands/SetZoneMaterialCommand';
 import { YaptideEditor } from '../../../../js/YaptideEditor';
-import { isSimulationMesh } from '../../../../Simulation/Base/SimulationMesh';
-import { isSimulationPoints } from '../../../../Simulation/Base/SimulationPoints';
-import { isSimulationZone, SimulationZone } from '../../../../Simulation/Base/SimulationZone';
 import { CustomStoppingPowerModels } from '../../../../Simulation/CustomStoppingPower/CustomStoppingPower';
-import { isBeam } from '../../../../Simulation/Physics/Beam';
 import { isScoringQuantity, ScoringQuantity } from '../../../../Simulation/Scoring/ScoringQuantity';
-import { isWorldZone } from '../../../../Simulation/Zones/WorldZone/WorldZone';
 import { MaterialSelect } from '../../../Select/MaterialSelect';
 import {
-	ColorInput,
 	ConditionalNumberPropertyField,
 	ConditionalPropertyField,
 	PropertyField
@@ -35,7 +26,10 @@ export function ScoringQuantityMaterialOverrides(props: {
 	const { state: watchedObject } = useSmartWatchEditorState(editor, object);
 
 	const visibleFlag =
-		isScoringQuantity(watchedObject) && watchedObject.keyword! && watchedObject.hasMaterial!;
+		isScoringQuantity(watchedObject) &&
+		editor.contextManager.currentSimulator !== SimulatorType.GEANT4 &&
+		watchedObject.keyword! &&
+		watchedObject.hasMaterial!;
 
 	const { state: editorPhysic } = useSmartWatchEditorState(editor, editor.physic);
 

--- a/src/ThreeEditor/components/Sidebar/properties/fields/PropertyField.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/fields/PropertyField.tsx
@@ -104,8 +104,12 @@ export function NumberInput(props: {
 	);
 
 	useEffect(() => {
+		inputRef.current.setUnit(props.unit);
+	}, [props.unit]);
+
+	useEffect(() => {
 		inputRef.current.setValue(props.value);
-	}, [props.value]);
+	}, [props.value, props.unit]);
 
 	useEffect(() => {
 		if (!boxRef.current) return;

--- a/src/ThreeEditor/components/Sidebar/properties/fields/PropertyField.tsx
+++ b/src/ThreeEditor/components/Sidebar/properties/fields/PropertyField.tsx
@@ -104,7 +104,9 @@ export function NumberInput(props: {
 	);
 
 	useEffect(() => {
-		inputRef.current.setUnit(props.unit);
+		if (props.unit) {
+			inputRef.current.setUnit(props.unit);
+		}
 	}, [props.unit]);
 
 	useEffect(() => {

--- a/src/ThreeEditor/js/EditorContext.ts
+++ b/src/ThreeEditor/js/EditorContext.ts
@@ -12,6 +12,7 @@ import {
 import { BasicFigure, isBasicFigure } from '../Simulation/Figures/BasicFigures';
 import { Beam, isBeam } from '../Simulation/Physics/Beam';
 import { isCustomFilter } from '../Simulation/Scoring/CustomFilter';
+import { isGeantScoringFilter } from '../Simulation/Scoring/GeantScoringFilter';
 import { isParticleFilter } from '../Simulation/Scoring/ParticleFilter';
 import { ScoringFilter } from '../Simulation/Scoring/ScoringFilter';
 import {
@@ -225,6 +226,7 @@ export const isScoringContextObject = (x: unknown): x is ScoringContextObject =>
 	return (
 		isCustomFilter(x) ||
 		isParticleFilter(x) ||
+		isGeantScoringFilter(x) ||
 		isFilterContainer(x) ||
 		isOutput(x) ||
 		isScoringQuantity(x) ||

--- a/src/ThreeEditor/js/commands/AddOutputCommand.js
+++ b/src/ThreeEditor/js/commands/AddOutputCommand.js
@@ -1,4 +1,5 @@
 import { ScoringOutput } from '../../Simulation/Scoring/ScoringOutput';
+import createScoringOutput from '../../Simulation/Scoring/ScoringOutputFactory';
 import { Command } from '../Command';
 
 export class AddOutputCommand extends Command {
@@ -42,6 +43,6 @@ export class AddOutputCommand extends Command {
 		super.fromSerialized(json);
 		this.object =
 			this.editor.scoringManager.getOutputByUuid(json.object.uuid) ??
-			new ScoringOutput().fromSerialized(json.object);
+			createScoringOutput(this.editor).fromSerialized(json.object);
 	}
 }

--- a/src/ThreeEditor/js/commands/AddQuantityCommand.js
+++ b/src/ThreeEditor/js/commands/AddQuantityCommand.js
@@ -1,4 +1,5 @@
 import { ScoringOutput } from '../../Simulation/Scoring/ScoringOutput';
+import createScoringOutput from '../../Simulation/Scoring/ScoringOutputFactory';
 import { ScoringQuantity } from '../../Simulation/Scoring/ScoringQuantity';
 import { Command } from '../Command';
 
@@ -44,7 +45,7 @@ export class AddQuantityCommand extends Command {
 		super.fromSerialized(json);
 		this.output =
 			this.editor.scoringManager.getOutputByUuid(json.object.uuid) ??
-			new ScoringOutput().fromSerialized(json.object);
+			createScoringOutput(this.editor).fromSerialized(json.object);
 
 		this.object =
 			this.output.getQuantityByUuid(json.object.uuid) ??

--- a/src/ThreeEditor/js/commands/RemoveQuantityCommand.js
+++ b/src/ThreeEditor/js/commands/RemoveQuantityCommand.js
@@ -1,4 +1,5 @@
 import { ScoringOutput } from '../../Simulation/Scoring/ScoringOutput';
+import createScoringOutput from '../../Simulation/Scoring/ScoringOutputFactory';
 import { ScoringQuantity } from '../../Simulation/Scoring/ScoringQuantity';
 import { Command } from '../Command';
 
@@ -42,7 +43,7 @@ export class RemoveQuantityCommand extends Command {
 		super.fromSerialized(json);
 		this.output =
 			this.editor.scoringManager.getOutputByUuid(json.object.uuid) ??
-			new ScoringOutput().fromSerialized(json.object);
+			createScoringOutput(this.editor).fromSerialized(json.object);
 
 		this.object =
 			this.output.getQuantityByUuid(json.object.uuid) ??

--- a/src/ThreeEditor/js/commands/SetOutputSettingsCommand.js
+++ b/src/ThreeEditor/js/commands/SetOutputSettingsCommand.js
@@ -1,4 +1,4 @@
-import { ScoringOutput } from '../../Simulation/Scoring/ScoringOutput';
+import createScoringOutput from '../../Simulation/Scoring/ScoringOutputFactory';
 import { Command } from '../Command';
 
 /**
@@ -54,6 +54,6 @@ export class SetOutputSettingsCommand extends Command {
 		this.newValue = json.newValue;
 		this.object =
 			this.editor.scoringManager.getObjectByUuid(json.object.uuid) ??
-			ScoringOutput.fromSerialized(json.object);
+			createScoringOutput(this.editor).fromSerialized(json.object);
 	}
 }

--- a/src/types/Particle.ts
+++ b/src/types/Particle.ts
@@ -4,7 +4,7 @@ export type Particle = {
 	id: number;
 	name: string;
 };
-export const PARTICLE_TYPES = [
+export const COMMON_PARTICLE_TYPES = [
 	{
 		id: 1,
 		name: 'Neutron'
@@ -75,5 +75,52 @@ export const FLUKA_PARTICLE_TYPES = [
 	{
 		id: 26,
 		name: 'Electron'
+	}
+] as const satisfies readonly ParticleType[];
+
+export const GEANT4_PARTICLE_TYPES = [
+	{
+		id: 1,
+		name: 'Neutron'
+	},
+	{
+		id: 2,
+		name: 'Proton'
+	},
+	{
+		id: 3,
+		name: 'Photon'
+	},
+	{
+		id: 4,
+		name: 'Electron'
+	},
+	{
+		id: 5,
+		name: 'Positron'
+	},
+	{
+		id: 6,
+		name: 'Alpha'
+	},
+	{
+		id: 7,
+		name: 'Muon µ-'
+	},
+	{
+		id: 8,
+		name: 'Muon µ+'
+	},
+	{
+		id: 9,
+		name: 'Pion π-'
+	},
+	{
+		id: 10,
+		name: 'Pion π+'
+	},
+	{
+		id: 11,
+		name: '12C'
 	}
 ] as const satisfies readonly ParticleType[];

--- a/src/types/ResponseTypes.ts
+++ b/src/types/ResponseTypes.ts
@@ -1,6 +1,5 @@
 import { Estimator, Page } from '../JsRoot/GraphData';
 import { EditorJson } from '../ThreeEditor/js/EditorJson';
-import { ScoringOutputJSON } from '../ThreeEditor/Simulation/Scoring/ScoringOutput';
 import { SimulationSourceType } from '../WrapperApp/components/Simulation/RunSimulationForm';
 import { DataWithStatus, LookUp, TypeIdentifiedByKey } from './TypeTransformUtil';
 

--- a/src/util/Ui/CommandButtonProps.ts
+++ b/src/util/Ui/CommandButtonProps.ts
@@ -14,6 +14,7 @@ import { GeantScoringFilter } from '../../ThreeEditor/Simulation/Scoring/GeantSc
 import { ParticleFilter } from '../../ThreeEditor/Simulation/Scoring/ParticleFilter';
 import { ScoringFilter } from '../../ThreeEditor/Simulation/Scoring/ScoringFilter';
 import { isOutput, ScoringOutput } from '../../ThreeEditor/Simulation/Scoring/ScoringOutput';
+import createScoringOutput from '../../ThreeEditor/Simulation/Scoring/ScoringOutputFactory';
 import {
 	isScoringQuantity,
 	ScoringQuantity
@@ -213,7 +214,7 @@ export const getAddElementButtonProps = (editor: YaptideEditor): GroupedCommandB
 			() => {
 				return commandFactory.createAddCommand(
 					'output',
-					new ScoringOutput(editor),
+					createScoringOutput(editor) as ScoringOutput,
 					editor.scoringManager
 				);
 			}

--- a/src/util/Ui/CommandButtonProps.ts
+++ b/src/util/Ui/CommandButtonProps.ts
@@ -10,6 +10,7 @@ import {
 	SphereFigure
 } from '../../ThreeEditor/Simulation/Figures/BasicFigures';
 import { CustomFilter } from '../../ThreeEditor/Simulation/Scoring/CustomFilter';
+import { GeantScoringFilter } from '../../ThreeEditor/Simulation/Scoring/GeantScoringFilter';
 import { ParticleFilter } from '../../ThreeEditor/Simulation/Scoring/ParticleFilter';
 import { ScoringFilter } from '../../ThreeEditor/Simulation/Scoring/ScoringFilter';
 import { isOutput, ScoringOutput } from '../../ThreeEditor/Simulation/Scoring/ScoringOutput';
@@ -161,30 +162,49 @@ export const getAddElementButtonProps = (editor: YaptideEditor): GroupedCommandB
 		]
 	];
 
-	const filtersTuple: CommandButtonTuple[] = [
-		[
-			'Particle filter',
-			() => {
-				return commandFactory.createAddCommand<'filter', ScoringFilter>(
-					'filter',
-					new ParticleFilter(editor),
-					editor.scoringManager
-				);
-			}
-		]
-	];
+	const filtersTuple: CommandButtonTuple[] = [];
 
-	if (editor.contextManager.currentSimulator === SimulatorType.SHIELDHIT) {
-		filtersTuple.unshift([
-			'Custom filter',
-			() => {
-				return commandFactory.createAddCommand<'filter', ScoringFilter>(
-					'filter',
-					new CustomFilter(editor),
-					editor.scoringManager
-				);
-			}
-		]);
+	switch (editor.contextManager.currentSimulator) {
+		// @ts-ignore
+		case SimulatorType.SHIELDHIT:
+			filtersTuple.push([
+				'Custom filter',
+				() => {
+					return commandFactory.createAddCommand<'filter', ScoringFilter>(
+						'filter',
+						new CustomFilter(editor),
+						editor.scoringManager
+					);
+				}
+			]);
+		// fallthrough
+		case SimulatorType.FLUKA:
+		case SimulatorType.COMMON:
+			filtersTuple.push([
+				'Particle filter',
+				() => {
+					return commandFactory.createAddCommand<'filter', ScoringFilter>(
+						'filter',
+						new ParticleFilter(editor),
+						editor.scoringManager
+					);
+				}
+			]);
+
+			break;
+		case SimulatorType.GEANT4:
+			filtersTuple.push([
+				'New filter',
+				() => {
+					return commandFactory.createAddCommand<'filter', ScoringFilter>(
+						'filter',
+						new GeantScoringFilter(editor),
+						editor.scoringManager
+					);
+				}
+			]);
+
+			break;
 	}
 
 	const outputsTuple: CommandButtonTuple[] = [

--- a/src/util/Ui/ReactUis.js
+++ b/src/util/Ui/ReactUis.js
@@ -4,7 +4,7 @@ import { MaterialSelect } from '../../ThreeEditor/components/Select/MaterialSele
 import { ParticleSelect } from '../../ThreeEditor/components/Select/ParticleSelect';
 import ZoneManagerPanel from '../../ThreeEditor/components/ZoneManagerPanel/ZoneManagerPanel';
 import { UIDiv, UINumber, UIRow, UISelect, UIText } from '../../ThreeEditor/js/libs/ui.js';
-import { PARTICLE_TYPES } from '../../types/Particle';
+import { COMMON_PARTICLE_TYPES } from '../../types/Particle';
 import { INPUT_WIDTH, LABEL_MARGIN, LABEL_WIDTH } from './Uis';
 
 /**
@@ -35,7 +35,7 @@ export function createParticleTypeSelect(update) {
 			input.setValue(value);
 			ReactDOM.render(
 				<ParticleSelect
-					particles={PARTICLE_TYPES}
+					particles={COMMON_PARTICLE_TYPES}
 					value={value}
 					onChange={onChange}
 				/>,


### PR DESCRIPTION
Resolves #2017 

Added scoring panel configuration for Geant4 roughly following mockups. Scoring quantites were selected after some discussions and testing, and are expected to work without the need to write loads of c++. Options for histogram definition and filters are available in macro files, according to geant docs.

For now, no validation is implemented (i.e <= 0 values for log scale) because this would require modifications to yaptide input handling and I'd rather do it in another PR.