### PR TITLE
Fix loading Geant4 figures from json

### DIFF
--- a/public/examples/ex8.json
+++ b/public/examples/ex8.json
@@ -77,7 +77,7 @@
 		"figures": [
 			{
 				"name": "World",
-				"type": "CylinderFigure",
+				"type": "Geant4Cylinder",
 				"uuid": "bd9533dc-2611-4645-801b-883953916fd6",
 				"visible": true,
 				"geometryData": {
@@ -94,7 +94,7 @@
 				"children": [
 					{
 						"name": "Vacuum_cylinder",
-						"type": "CylinderFigure",
+						"type": "Geant4Cylinder",
 						"uuid": "f94994c6-a14e-4a40-97cc-84caa873075e",
 						"visible": true,
 						"geometryData": {
@@ -111,7 +111,7 @@
 						"children": [
 							{
 								"name": "Water_phantom_cylinder",
-								"type": "CylinderFigure",
+								"type": "Geant4Cylinder",
 								"uuid": "31e3ac1c-ea6c-43a0-9533-8316748f6f0c",
 								"visible": true,
 								"geometryData": {
@@ -125,11 +125,32 @@
 									}
 								},
 								"colorHex": 0,
-								"children": []
+								"children": [],
+								"simulationMaterial": {
+									"icru": 276,
+									"name": "WATER, LIQUID",
+									"sanitized_name": "water_liquid",
+									"density": 1,
+									"geant4_name": "G4_WATER"
+								}
 							}
-						]
+						],
+						"simulationMaterial": {
+							"icru": 1000,
+							"name": "VACUUM",
+							"sanitized_name": "vacuum",
+							"density": 0,
+							"geant4_name": "G4_Galactic"
+						}
 					}
-				]
+				],
+				"simulationMaterial": {
+					"icru": 0,
+					"name": "BLACK HOLE",
+					"sanitized_name": "black_hole",
+					"density": 0,
+					"geant4_name": "BlackHole"
+				}
 			}
 		]
 	},

--- a/src/ThreeEditor/Simulation/Figures/BasicFigures.ts
+++ b/src/ThreeEditor/Simulation/Figures/BasicFigures.ts
@@ -83,9 +83,10 @@ export class BoxFigure extends BasicFigure<THREE.BoxGeometry> {
 	constructor(
 		editor: YaptideEditor,
 		geometry?: THREE.BoxGeometry,
-		material?: THREE.MeshBasicMaterial
+		material?: THREE.MeshBasicMaterial,
+		type: string = 'BoxFigure'
 	) {
-		super(editor, 'Box', 'BoxFigure', 'BoxGeometry', geometry ?? boxGeometry, material);
+		super(editor, 'Box', type, 'BoxGeometry', geometry ?? boxGeometry, material);
 	}
 
 	reconstructGeometryFromData(data: AdditionalGeometryDataType<BoxParameters>): void {
@@ -103,12 +104,13 @@ export class CylinderFigure extends BasicFigure<HollowCylinderGeometry> {
 	constructor(
 		editor: YaptideEditor,
 		geometry?: HollowCylinderGeometry,
-		material?: THREE.MeshBasicMaterial
+		material?: THREE.MeshBasicMaterial,
+		type: string = 'CylinderFigure'
 	) {
 		super(
 			editor,
 			'Cylinder',
-			'CylinderFigure',
+			type,
 			'HollowCylinderGeometry',
 			geometry ?? cylinderGeometry,
 			material
@@ -139,16 +141,10 @@ export class SphereFigure extends BasicFigure<THREE.SphereGeometry> {
 	constructor(
 		editor: YaptideEditor,
 		geometry?: THREE.SphereGeometry,
-		material?: THREE.MeshBasicMaterial
+		material?: THREE.MeshBasicMaterial,
+		type: string = 'SphereFigure'
 	) {
-		super(
-			editor,
-			'Sphere',
-			'SphereFigure',
-			'SphereGeometry',
-			geometry ?? sphereGeometry,
-			material
-		);
+		super(editor, 'Sphere', type, 'SphereGeometry', geometry ?? sphereGeometry, material);
 	}
 
 	reconstructGeometryFromData(data: AdditionalGeometryDataType<SphereParameters>): void {
@@ -226,7 +222,7 @@ export class Geant4Box extends BoxFigure {
 		material?: THREE.MeshBasicMaterial,
 		simulationMaterial: SimulationMaterialType = DEFAULT_SIMULATION_MATERIAL
 	) {
-		super(editor, geometry, material);
+		super(editor, geometry, material, 'Geant4Box');
 		this.simulationMaterial = simulationMaterial;
 	}
 
@@ -256,7 +252,7 @@ export class Geant4Cylinder extends CylinderFigure {
 		material?: THREE.MeshBasicMaterial,
 		simulationMaterial: SimulationMaterialType = DEFAULT_SIMULATION_MATERIAL
 	) {
-		super(editor, geometry, material);
+		super(editor, geometry, material, 'Geant4Cylinder');
 		this.simulationMaterial = simulationMaterial;
 	}
 
@@ -286,7 +282,7 @@ export class Geant4Sphere extends SphereFigure {
 		material?: THREE.MeshBasicMaterial,
 		simulationMaterial: SimulationMaterialType = DEFAULT_SIMULATION_MATERIAL
 	) {
-		super(editor, geometry, material);
+		super(editor, geometry, material, 'Geant4Sphere');
 		this.simulationMaterial = simulationMaterial;
 	}
 

--- a/src/ThreeEditor/Simulation/Figures/FigureManager.ts
+++ b/src/ThreeEditor/Simulation/Figures/FigureManager.ts
@@ -7,7 +7,16 @@ import { SimulationSceneContainer } from '../Base/SimulationContainer';
 import { SimulationElementJSON } from '../Base/SimulationElement';
 import { SimulationElementManager } from '../Base/SimulationManager';
 import { SimulationMeshJSON } from '../Base/SimulationMesh';
-import { BasicFigure, BoxFigure, CylinderFigure, SphereFigure } from './BasicFigures';
+import {
+	BasicFigure,
+	BoxFigure,
+	CylinderFigure,
+	Geant4Box,
+	Geant4Cylinder,
+	Geant4FigureJSON,
+	Geant4Sphere,
+	SphereFigure
+} from './BasicFigures';
 
 type FigureManagerJSON = Omit<
 	SimulationElementJSON & {
@@ -25,6 +34,12 @@ export const figureLoader = (editor: YaptideEditor) => (json: SimulationMeshJSON
 			return new CylinderFigure(editor).fromSerialized(json);
 		case 'SphereFigure':
 			return new SphereFigure(editor).fromSerialized(json);
+		case 'Geant4Box':
+			return new Geant4Box(editor).fromSerialized(json as Geant4FigureJSON);
+		case 'Geant4Cylinder':
+			return new Geant4Cylinder(editor).fromSerialized(json as Geant4FigureJSON);
+		case 'Geant4Sphere':
+			return new Geant4Sphere(editor).fromSerialized(json as Geant4FigureJSON);
 		default:
 			throw new Error(`Unknown figure type: ${json.type}`);
 	}


### PR DESCRIPTION
It seems that we didn't implement loading Geant4 figures from project JSON. Figures were saved with types from other simulators (CylinderFigure, BoxFigure, SphereFigure instead of Geant4Cylinder, Geant4Box, Geant4Sphere) and were rebuilt as though they were the former. This didn't fail on Geant4, but resulted in them not having material assigned.

Geant4 example has been updated accordintly, it should load the correct materials now.