### PR TITLE
Fix start button triggering condition, fix Last 5 simulations not displaying in demo mode

### DIFF
--- a/src/WrapperApp/components/Simulation/RecentSimulations.tsx
+++ b/src/WrapperApp/components/Simulation/RecentSimulations.tsx
@@ -49,8 +49,7 @@ export default function RecentSimulations() {
 
 	const [controller] = useState(new AbortController());
 
-	const config: SimulationConfig = {
-		shouldConnect: !demoMode,
+	const config: Omit<SimulationConfig, 'shouldConnect'> = {
 		controller,
 		trackedId,
 		isBackendAlive,
@@ -63,6 +62,8 @@ export default function RecentSimulations() {
 			StatusState.COMPLETED
 		]
 	};
+	const remoteWorkerSimulationConfig = { ...config, shouldConnect: !demoMode };
+	const geant4LocalWorkerSimulationConfig = { ...config, shouldConnect: true };
 
 	const remoteWorkerState: SimulationState = {
 		simulationInfo: remoteWorkerSimulationInfo,
@@ -96,17 +97,25 @@ export default function RecentSimulations() {
 		simulationDataInterval: remoteWorkerSimulationDataInterval,
 		handleLoadResults: remoteWorkerHandleLoadResults,
 		setPageCount: setRemoteWorkerPageCount
-	} = SimulationsGridHelpers(config, remoteWorkerSimulationHandlers, remoteWorkerState);
+	} = SimulationsGridHelpers(
+		remoteWorkerSimulationConfig,
+		remoteWorkerSimulationHandlers,
+		remoteWorkerState
+	);
 
 	const {
 		updateSimulationInfo: geant4LocalWorkerUpdateSimulationInfo,
 		updateSimulationData: geant4LocalWorkerUpdateSimulationData,
 		simulationDataInterval: geant4LocalWorkerSimulationDataInterval,
 		handleLoadResults: geant4LocalWorkerHandleLoadResults
-	} = SimulationsGridHelpers(config, geant4LocalWorkerSimulationHandlers, geant4LocalWorkerState);
+	} = SimulationsGridHelpers(
+		geant4LocalWorkerSimulationConfig,
+		geant4LocalWorkerSimulationHandlers,
+		geant4LocalWorkerState
+	);
 
 	useBackendAliveEffect(
-		config,
+		remoteWorkerSimulationConfig,
 		remoteWorkerSimulationHandlers,
 		() => {
 			if (auth.isAuthorized) {
@@ -117,15 +126,20 @@ export default function RecentSimulations() {
 	);
 
 	useBackendAliveEffect(
-		config,
+		geant4LocalWorkerSimulationConfig,
 		geant4LocalWorkerSimulationHandlers,
 		geant4LocalWorkerUpdateSimulationInfo,
 		setRemoteWorkerPageCount
 	);
 
-	useUpdateCurrentSimulationEffect(config, remoteWorkerSimulationHandlers, remoteWorkerState);
 	useUpdateCurrentSimulationEffect(
-		config,
+		remoteWorkerSimulationConfig,
+		remoteWorkerSimulationHandlers,
+		remoteWorkerState
+	);
+
+	useUpdateCurrentSimulationEffect(
+		geant4LocalWorkerSimulationConfig,
 		geant4LocalWorkerSimulationHandlers,
 		geant4LocalWorkerState
 	);

--- a/src/WrapperApp/components/Simulation/RunSimulationForm.tsx
+++ b/src/WrapperApp/components/Simulation/RunSimulationForm.tsx
@@ -186,11 +186,10 @@ export function RunSimulationForm({
 	const [runPreconditionsMet, setRunPreconditionsMet] = useState(false);
 
 	useEffect(() => {
-		setRunPreconditionsMet(
-			!isNaN(nTasks) &&
-				!isNaN(overridePrimariesCount) &&
-				(currentSimulator !== SimulatorType.GEANT4 || isConverterReady)
-		);
+		const runFormIsValid = !isNaN(nTasks) && !isNaN(overridePrimariesCount);
+		const converterReadyIfGeant4Selected =
+			currentSimulator !== SimulatorType.GEANT4 || isConverterReady;
+		setRunPreconditionsMet(runFormIsValid && converterReadyIfGeant4Selected);
 	}, [nTasks, overridePrimariesCount, currentSimulator, isConverterReady]);
 
 	const toggleFileSelection = (fileName: string) =>
@@ -227,7 +226,7 @@ export function RunSimulationForm({
 	};
 
 	const handleRunSimulationClick = () => {
-		if (runPreconditionsMet) {
+		if (!runPreconditionsMet) {
 			return;
 		}
 


### PR DESCRIPTION
This pull request refactors how simulation configuration is handled in the `RecentSimulations` component and improves the logic for enabling the simulation run button in `RunSimulationForm`. The main changes are focused on making simulation configuration more explicit for different worker types and clarifying form validation logic.

**Simulation configuration refactor:**

* Split the `SimulationConfig` object into two distinct configs (`remoteWorkerSimulationConfig` and `geant4LocalWorkerSimulationConfig`) to explicitly set the `shouldConnect` property for each simulation type instead of passing it as part of a shared config. This makes the code clearer and avoids accidental misconfiguration. [[1]](diffhunk://#diff-854bab89b1b6fecee4f669cc9d2213bee8693fc419599545458062cd4f186cb9L52-R52) [[2]](diffhunk://#diff-854bab89b1b6fecee4f669cc9d2213bee8693fc419599545458062cd4f186cb9R65-R66)
* Updated all usages of simulation helpers and effects (`SimulationsGridHelpers`, `useBackendAliveEffect`, `useUpdateCurrentSimulationEffect`) to use the correct configuration object for each worker type, ensuring each simulation type behaves as intended. [[1]](diffhunk://#diff-854bab89b1b6fecee4f669cc9d2213bee8693fc419599545458062cd4f186cb9L99-R118) [[2]](diffhunk://#diff-854bab89b1b6fecee4f669cc9d2213bee8693fc419599545458062cd4f186cb9L120-R142)

**Run simulation form validation improvements:**

* Refactored the logic for enabling the "Run Simulation" button by separating the validation of numeric fields and the readiness of the converter for Geant4 simulations, making the code easier to understand and maintain.
* Fixed the click handler for running simulations to properly disable the button when preconditions are not met, preventing unintended simulation runs.