### PR TITLE
Fix Last 5 simulations glitching when there's not enough room

### DIFF
--- a/src/WrapperApp/components/Simulation/RecentSimulations.tsx
+++ b/src/WrapperApp/components/Simulation/RecentSimulations.tsx
@@ -228,7 +228,6 @@ export default function RecentSimulations() {
 			sx={{
 				'margin': `0 ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(1)}`,
 				'flexGrow': 1,
-				'minHeight': 0,
 				'display': 'flex',
 				'flexDirection': 'column',
 				'& .MuiCollapse-root': {


### PR DESCRIPTION
This PR fixes a visual glitch for Last 5 simulations section

Before
<img width="443" height="126" alt="image" src="https://github.com/user-attachments/assets/12b9e320-7da0-4e08-9fce-f946d5525cb5" />

After
<img width="418" height="88" alt="image" src="https://github.com/user-attachments/assets/2860719e-9fe0-4b23-842f-e9f79951c81a" />
